### PR TITLE
Use a more specific expecation in a test.

### DIFF
--- a/spec/units/transcoding_spec.rb
+++ b/spec/units/transcoding_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "Transcoder" do
-  before do
+  before(:all) do
     class ContentDatastream < ActiveFedora::Datastream
       include Hydra::Derivatives::ExtractMetadata
     end
@@ -40,6 +40,11 @@ describe "Transcoder" do
       end
 
     end
+  end
+
+  after(:all) do
+    Object.send(:remove_const, :GenericFile);
+    Object.send(:remove_const, :ContentDatastream);
   end
   
   describe "with an attached image" do
@@ -89,7 +94,7 @@ describe "Transcoder" do
     let(:file) { GenericFile.new(mime_type: 'audio/wav').tap { |t| t.content.content = attachment; t.content.mimeType = 'audio/vnd.wav'; t.save } }
 
     it "should transcode" do
-      expect(logger).to receive(:warn).with("Unable to find a registered mime type for \"audio/vnd.wav\" on #{file.pid}").at_least(1).times
+      expect(logger).to receive(:warn).with("Unable to find a registered mime type for \"audio/vnd.wav\" on #{file.pid}").twice
       file.create_derivatives
       file.datastreams['content_mp3'].should have_content
       file.datastreams['content_mp3'].mimeType.should == 'audio/mpeg'


### PR DESCRIPTION
We only want to run through the transcoding directive twice.
However it was unable to be measured before because we were
creating a new directive on each test run. Fixed by only creating
the class once.
