### PR TITLE
Replacing rmagick with mini_magick

### DIFF
--- a/hydra-derivatives.gemspec
+++ b/hydra-derivatives.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
 
   spec.add_dependency 'active-fedora'
-  spec.add_dependency 'rmagick'
+  spec.add_dependency 'mini_magick'
   spec.add_dependency 'activesupport', '>= 3.2.13', '< 5.0'
 end
 

--- a/lib/hydra/derivatives.rb
+++ b/lib/hydra/derivatives.rb
@@ -1,5 +1,4 @@
 require 'active_fedora'
-require 'RMagick'
 module Hydra
   module Derivatives
     extend ActiveSupport::Concern


### PR DESCRIPTION
I am extremely biased against Rmagick. It is a memory hog and I have
always found it painful to install.
See https://github.com/minimagick/minimagick#why

MiniMagick instead spawns ImageMagick command line commands which use
significantly less memory.
See https://github.com/minimagick/minimagick#solution

Need more?

Building Rmagick requires install imagemagick developer packages,
instead of the less complicated and readily available imagemagick
package. Those developer packages are not available on REL6 and
require porting something over from CentOS.

And did I mention that MiniMagick requires a subset of the
dependencies of RMagick.

And building RMagick from source is a pain. My sysadmin told me so.
