### PR TITLE
Adding rewind to allow image data to be extracted properly

### DIFF
--- a/lib/hydra/derivatives/extract_metadata.rb
+++ b/lib/hydra/derivatives/extract_metadata.rb
@@ -26,6 +26,7 @@ module Hydra
             f.write(content)
           end
           content.rewind if content.respond_to? :rewind
+          f.rewind
           yield(f)
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,3 +7,4 @@ require 'hydra/derivatives'
 RSpec.configure do |config|
 end
 
+$in_travis = !ENV['TRAVIS'].nil? && ENV['TRAVIS'] == 'true'

--- a/spec/units/extract_spec.rb
+++ b/spec/units/extract_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+class ExtractThing < ActiveFedora::Datastream
+  include Hydra::Derivatives::ExtractMetadata
+  attr_accessor :pid
+end
+
+describe Hydra::Derivatives::ExtractMetadata, :unless => $in_travis do
+  let(:subject) { ExtractThing.new }
+  let(:attachment) { File.open(File.expand_path('../../fixtures/world.png', __FILE__))}
+
+  describe "Image Content" do
+    it "should get a mime type" do
+      subject.content = attachment
+      subject.pid = "abc"
+      xml = subject.extract_metadata
+      doc = Nokogiri::HTML(xml)
+      identity = doc.xpath('//identity').first
+      identity.attr('mimetype').should == 'image/png'
+    end
+  end
+end


### PR DESCRIPTION
When the rewind is not present the mime type comes back as application/empty.
