### PR TITLE
Restoring #to_tempfile

### DIFF
--- a/config/jetty.yml
+++ b/config/jetty.yml
@@ -1,6 +1,6 @@
 default:
   jetty_port: <%= ENV['TEST_JETTY_PORT'] || 8983 %>
-  startup_wait: 60
+  startup_wait: 90
   java_opts:
     - "-Xmx256m" 
     - "-XX:MaxPermSize=128m"

--- a/lib/hydra/derivatives/extract_metadata.rb
+++ b/lib/hydra/derivatives/extract_metadata.rb
@@ -5,8 +5,24 @@ module Hydra
 
       def extract_metadata
         return unless has_content?
-        Hydra::FileCharacterization.characterize(content, filename_for_characterization, :fits) do |config|
+        Hydra::FileCharacterization.characterize(content, filename_for_characterization.join(""), :fits) do |config|
           config[:fits] = Hydra::Derivatives.fits_path
+        end
+      end
+
+      # Restored method. It was required by other creatures
+      def to_tempfile(&block)
+        return unless has_content?
+        Tempfile.open(filename_for_characterization) do |f|
+          f.binmode
+          if content.respond_to? :read
+            f.write(content.read)
+          else
+            f.write(content)
+          end
+          content.rewind if content.respond_to? :rewind
+          f.rewind
+          yield(f)
         end
       end
 
@@ -16,7 +32,7 @@ module Hydra
         mime_type = MIME::Types[mimeType].first
         logger.warn "Unable to find a registered mime type for #{mimeType.inspect} on #{pid}" unless mime_type
         extension = mime_type ? ".#{mime_type.extensions.first}" : ''
-        "#{pid}-#{dsVersionID}#{extension}"
+        ["#{pid}-#{dsVersionID}", "#{extension}"]
       end
 
     end

--- a/spec/lib/hydra/derivatives/extract_metadata_spec.rb
+++ b/spec/lib/hydra/derivatives/extract_metadata_spec.rb
@@ -29,5 +29,11 @@ module Hydra::Derivatives
         its(:extract_metadata) { should match("<identity format=\"Plain text\" mimetype=\"text/plain\"")}
       end
     end
+
+    context '#to_tempfile' do
+      it 'has a method called to_tempfile' do
+        expect { |b| subject.to_tempfile(&b) }.to yield_with_args(Tempfile)
+      end
+    end
   end
 end


### PR DESCRIPTION
Other modules were dependent on the existence of this method.
At a future point, this method should be removed in favor of a more
generalized Conversion method Tempfile(object)
