### PR TITLE
Switch to streamio_ffmpeg for easier handling of ffmpeg arguments

### DIFF
--- a/hydra-derivatives.gemspec
+++ b/hydra-derivatives.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'active-fedora'
   spec.add_dependency 'hydra-file_characterization'
   spec.add_dependency 'mini_magick'
+  spec.add_dependency 'streamio-ffmpeg'
   spec.add_dependency 'activesupport', '>= 3.2.13', '< 5.0'
 end
 

--- a/lib/hydra/derivatives/ffmpeg.rb
+++ b/lib/hydra/derivatives/ffmpeg.rb
@@ -1,24 +1,44 @@
 # An abstract class for asyncronous jobs that transcode files using FFMpeg
 
 require 'tmpdir'
-require 'open3'
+require 'streamio-ffmpeg'
 
 module Hydra
   module Derivatives
     module Ffmpeg
       extend ActiveSupport::Concern
 
-      included do
-        include ShellBasedProcessor
-      end
+        def process
+          directives.each do |name, args| 
+            format = args[:format]
+            raise ArgumentError, "You must provide the :format you want to transcode into. You provided #{args}" unless format
+            # TODO if the source is in the correct format, we could just copy it and skip transcoding.
+            output_datastream_name = args[:datastream] || output_datastream_id(name)
+            options = args.reject {|k, v| [:format, :datastream].include? k }
+            options = {custom: options_for(format)} if options.empty?
+            encode_datastream(output_datastream_name, format, new_mime_type(format), options)
+          end
+        end
 
+        # override this method in subclass if you want to provide specific options.
+        def options_for(format)
+        end
 
-      module ClassMethods
+        def encode_datastream(dest_dsid, file_suffix, mime_type, options)
+          out_file = nil
+          output_file = Dir::Tmpname.create(['sufia', ".#{file_suffix}"], Hydra::Derivatives.temp_file_base){}
+          source_datastream.to_tempfile do |f|
+            encode(f.path, options, output_file)
+          end
+          out_file = File.open(output_file, "rb")
+          object.add_file_datastream(out_file.read, :dsid=>dest_dsid, :mimeType=>mime_type)
+          File.unlink(output_file)
+        end
 
         def encode(path, options, output_file)
-          execute "#{Hydra::Derivatives.ffmpeg_path} -y -i \"#{path}\" #{options} #{output_file}"
+          movie = FFMPEG::Movie.new(path)
+          movie.transcode(output_file, options)
         end
-      end
 
     end
   end

--- a/spec/units/video_spec.rb
+++ b/spec/units/video_spec.rb
@@ -3,22 +3,29 @@ require 'spec_helper'
 describe Hydra::Derivatives::Video do
   describe "when arguments are passed as a hash" do
     describe "and datastream is provided as an argument" do
-      let(:directives) {{ :thumb => {format: "webm", datastream: 'thumbnail'} }}
+      let(:directives) {{ :webm => {format: "webm", datastream: 'video'} }}
       subject { Hydra::Derivatives::Video.new(double(:obj), 'content', directives)}
       it "should create a datastream with the specified name" do
-        subject.should_receive(:encode_datastream).with("thumbnail", "webm", 'video/webm', "-s 320x240 -g 30 -b:v 345k -acodec libvorbis -ac 2 -ab 96k -ar 44100")
+        subject.should_receive(:encode_datastream).with("video", "webm", 'video/webm', {:custom=>"-s 320x240 -g 30 -b:v 345k -acodec libvorbis -ac 2 -ab 96k -ar 44100"})
         subject.process
-
       end
     end
 
     describe "and datastream is not provided as an argument" do
-      let(:directives) {{ :thumb => {format: "webm"} }}
+      let(:directives) {{ :webm => {format: "webm"} }}
       subject { Hydra::Derivatives::Video.new(double(:obj), 'content', directives)}
       it "should create a datastream and infer the name" do
-        subject.should_receive(:encode_datastream).with("content_thumb", "webm", 'video/webm', "-s 320x240 -g 30 -b:v 345k -acodec libvorbis -ac 2 -ab 96k -ar 44100")
+        subject.should_receive(:encode_datastream).with("content_webm", "webm", 'video/webm', {:custom=>"-s 320x240 -g 30 -b:v 345k -acodec libvorbis -ac 2 -ab 96k -ar 44100"})
         subject.process
+      end
+    end
 
+    describe "and ffmpeg options are provided as a hash" do
+      let(:directives) {{ :webm => {format: "webm", resolution: '320x240', keyframe_interval: 30, video_bitrate: 345, audio_codec: 'libfdk_aac', audio_channels: 2, audio_bitrate: 128, audio_sample_rate: 44100} }}
+      subject { Hydra::Derivatives::Video.new(double(:obj), 'content', directives)}
+      it "should create a datastream and infer the name" do
+        subject.should_receive(:encode_datastream).with("content_webm", "webm", 'video/webm', {resolution: '320x240', keyframe_interval: 30, video_bitrate: 345, audio_codec: 'libfdk_aac', audio_channels: 2, audio_bitrate: 128, audio_sample_rate: 44100})
+        subject.process
       end
     end
   end


### PR DESCRIPTION
Streamio_ffmpeg abstracts the ffmpeg arguments to insulate us from changes and configuration from the transform_datastream directive.
