### PR TITLE
Use a string rather than symbol when reading recipe from a hash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Or a class like this:
           when 'image/png', 'image/jpg'
             transform_datastream :content, { :medium => "300x300>", :thumb => {size: "100x100>", datastream: 'thumbnail'} }
           when 'image/tiff'
-            obj.transform_datastream :content, { :service => { recipe: :default } }, processor: 'jpeg2k_image'
+            transform_datastream :content, { :service => { recipe: :default } }, processor: 'jpeg2k_image'
           end
         end
     end

--- a/lib/hydra/derivatives/jpeg2k_config.yml
+++ b/lib/hydra/derivatives/jpeg2k_config.yml
@@ -1,0 +1,20 @@
+defaults: &defaults
+  jp2_recipes:
+    # note that these aren't real recipes, just enough to test configuration options
+    myrecipe_color: >
+      -rate 2.4
+      -jp2_space sRGB 
+      Stiles=\{1024,1024\}
+    myrecipe_grey: >
+      -rate 2.4
+      -jp2_space sLUM 
+      Stiles=\{1024,1024\}
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/lib/hydra/derivatives/jpeg2k_image.rb
+++ b/lib/hydra/derivatives/jpeg2k_image.rb
@@ -1,5 +1,7 @@
 require 'mini_magick'
 require 'nokogiri'
+
+
 module Hydra
   module Derivatives
     class Jpeg2kImage < Processor 
@@ -83,23 +85,23 @@ module Hydra
 
       def self.kdu_compress_recipe(args, quality, long_dim)
         if args[:recipe].is_a? Symbol
-          recipe = [args[:recipe].to_s, quality].join('_').to_sym
+          recipe = [args[:recipe].to_s, quality].join('_')
           if Hydra::Derivatives.kdu_compress_recipes.has_key? recipe
             return Hydra::Derivatives.kdu_compress_recipes[recipe]
           else
-            logger.warn "No JP2 recipe for #{args[:recipe].to_s} found in configuration. Using best guess."
-            return calcuate_recipe(args,quality,long_dim)
+            logger.warn "No JP2 recipe for :#{args[:recipe].to_s} ('#{recipe}') found in configuration. Using best guess."
+            return Hydra::Derivatives::Jpeg2kImage.calculate_recipe(args,quality,long_dim)
           end
         elsif args[:recipe].is_a? String
           return args[:recipe]
         else
-          return calculate_recipe(args,quality,long_dim)
+          return Hydra::Derivatives::Jpeg2kImage.calculate_recipe(args, quality, long_dim)
         end
       end
 
       def self.calculate_recipe(args, quality, long_dim)
-        levels_arg = args.fetch(:levels, level_count_for_size(long_dim))
-        rates_arg = layer_rates(args.fetch(:layers, 8), args.fetch(:compression, 10))
+        levels_arg = args.fetch(:levels, Hydra::Derivatives::Jpeg2kImage.level_count_for_size(long_dim))
+        rates_arg = Hydra::Derivatives::Jpeg2kImage.layer_rates(args.fetch(:layers, 8), args.fetch(:compression, 10))
         tile_size = args.fetch(:tile_size, 1024)
         tiles_arg = "\{#{tile_size},#{tile_size}\}"
         jp2_space_arg = quality == 'grey' ? 'sLUM' : 'sRGB'

--- a/spec/fixtures/jpeg2k_config.yml
+++ b/spec/fixtures/jpeg2k_config.yml
@@ -1,0 +1,20 @@
+defaults: &defaults
+  jp2_recipes:
+    # note that these aren't real recipes, just enough to test configuration options
+    myrecipe_color: >
+      -rate 2.4
+      -jp2_space sRGB 
+      Stiles=\{1024,1024\}
+    myrecipe_grey: >
+      -rate 2.4
+      -jp2_space sLUM 
+      Stiles=\{1024,1024\}
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/spec/units/jpeg2k_spec.rb
+++ b/spec/units/jpeg2k_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
+require 'yaml'
 
 describe Hydra::Derivatives::Jpeg2kImage do
   let(:object) { ActiveFedora::Base.new }
 
-  describe "#calculate recipe" do
+  describe "#calculate_recipe" do
     it "calculates the number of levels from a size" do
       dim = 7200
       Hydra::Derivatives::Jpeg2kImage.level_count_for_size(dim).should == 6
@@ -15,6 +16,39 @@ describe Hydra::Derivatives::Jpeg2kImage do
       calc = Hydra::Derivatives::Jpeg2kImage.layer_rates(layers, compression_num) 
       calc.should == "2.4,1.48331273,0.91675694,0.56659885,0.3501847,0.21643059,0.13376427,0.0826726"
     end
+
+  end
+
+  describe "#kdu_compress_recipe" do
+    before(:all) do
+      @sample_cfg = YAML.load_file(File.expand_path('../../fixtures/jpeg2k_config.yml', __FILE__))['test']
+      Hydra::Derivatives.kdu_compress_recipes = @sample_cfg['jp2_recipes']
+    end
+
+    it "can get the recipe from a config file" do
+      args = { recipe: :myrecipe }
+      r = Hydra::Derivatives::Jpeg2kImage.kdu_compress_recipe(args, 'grey', 7200)
+      r.should == @sample_cfg['jp2_recipes']['myrecipe_grey']
+    end
+
+    it "can take a recipe as a string" do
+      args = { recipe: '-my -excellent -recipe' }
+      r = Hydra::Derivatives::Jpeg2kImage.kdu_compress_recipe(args, 'grey', 7200)
+      r.should == args[:recipe]
+    end
+
+    it "will fall back to a #calculate_recipe if a symbol is passed but no recipe is found" do
+      args = { recipe: :x }
+      r = Hydra::Derivatives::Jpeg2kImage.kdu_compress_recipe(args, 'grey', 7200)
+      r.should == Hydra::Derivatives::Jpeg2kImage.calculate_recipe(args, 'grey', 7200)
+    end
+
+    it "will fall back to a #calculate_recipe if there is no attempt to provide one" do
+      args = {}
+      r = Hydra::Derivatives::Jpeg2kImage.kdu_compress_recipe(args, 'grey', 7200)
+      r.should == Hydra::Derivatives::Jpeg2kImage.calculate_recipe(args, 'grey', 7200)
+    end
+
   end
 
 end


### PR DESCRIPTION
Closes projecthydra/hydra-derivatives#28

This and a couple of other small bugs were being masked by the fact that #kdu_compress_recipe always falls back to a default recipe:

https://github.com/jpstroop/hydra-derivatives/blob/add_jp2_support/lib/hydra/derivatives/jpeg2k_image.rb#L84-L98

simply testing that the stream had content was not sufficient. Additional tests to check that we're getting the intended recipe are included.
