### PR TITLE
update kakadu paramaters with recommended escaping

### DIFF
--- a/lib/hydra/derivatives/config.rb
+++ b/lib/hydra/derivatives/config.rb
@@ -1,7 +1,7 @@
 module Hydra
   module Derivatives
     class Config
-      attr_writer :ffmpeg_path, :libreoffice_path, :temp_file_base, :fits_path, 
+      attr_writer :ffmpeg_path, :libreoffice_path, :temp_file_base, :fits_path,
         :enable_ffmpeg, :kdu_compress_path, :kdu_compress_recipes
       def ffmpeg_path
         @ffmpeg_path ||= 'ffmpeg'
@@ -29,34 +29,34 @@ module Hydra
 
       def kdu_compress_recipes
         @kdu_compress_recipes ||= {
-          default_color: %Q{-rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171 
-            -jp2_space sRGB 
-            -double_buffering 10 
-            -num_threads 4 
-            -no_weights 
-            Clevels=6 
-            Clayers=8 
-            Cblk=\{64,64\} 
-            Cuse_sop=yes 
-            Cuse_eph=yes  
-            Corder=RPCL 
-            ORGgen_plt=yes 
-            ORGtparts=R 
-            Stiles=\{1024,1024\} }.gsub(/\s+/, " ").strip,
-          default_grey: %Q{-rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171 
-            -jp2_space sLUM 
-            -double_buffering 10 
-            -num_threads 4 
-            -no_weights 
-            Clevels=6 
-            Clayers=8 
-            Cblk=\{64,64\} 
-            Cuse_sop=yes 
-            Cuse_eph=yes  
-            Corder=RPCL 
-            ORGgen_plt=yes 
-            ORGtparts=R 
-            Stiles=\{1024,1024\} }.gsub(/\s+/, " ").strip
+          default_color: %Q{-rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171
+            -jp2_space sRGB
+            -double_buffering 10
+            -num_threads 4
+            -no_weights
+            Clevels=6
+            Clayers=8
+            "Cblk={64,64}"
+            Cuse_sop=yes
+            Cuse_eph=yes
+            Corder=RPCL
+            ORGgen_plt=yes
+            ORGtparts=R
+            "Stiles={1024,1024}" }.gsub(/\s+/, " ").strip,
+          default_grey: %Q{-rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171
+            -jp2_space sLUM
+            -double_buffering 10
+            -num_threads 4
+            -no_weights
+            Clevels=6
+            Clayers=8
+            "Cblk={64,64}"
+            Cuse_sop=yes
+            Cuse_eph=yes
+            Corder=RPCL
+            ORGgen_plt=yes
+            ORGtparts=R
+            "Stiles={1024,1024}" }.gsub(/\s+/, " ").strip
         }
       end
 

--- a/lib/hydra/derivatives/jpeg2k_image.rb
+++ b/lib/hydra/derivatives/jpeg2k_image.rb
@@ -4,7 +4,7 @@ require 'nokogiri'
 
 module Hydra
   module Derivatives
-    class Jpeg2kImage < Processor 
+    class Jpeg2kImage < Processor
       include ShellBasedProcessor
 
       def process
@@ -38,7 +38,7 @@ module Hydra
         object.add_file_datastream(out_file.read, dsid: dest_dsid, mimeType: 'image/jp2')
         File.unlink(output_file)
       end
-      
+
       protected
       def preprocess(image, opts={})
         # resize: <geometry>, to_srgb: <bool>, src_quality: 'color'|'gray'
@@ -57,7 +57,7 @@ module Hydra
       def self.srgb_profile_path
         File.join [
           File.expand_path('../../../', __FILE__),
-          'color_profiles', 
+          'color_profiles',
           'sRGB_IEC61966-2-1_no_black_scaling.icc'
         ]
       end
@@ -90,21 +90,21 @@ module Hydra
         levels_arg = args.fetch(:levels, Hydra::Derivatives::Jpeg2kImage.level_count_for_size(long_dim))
         rates_arg = Hydra::Derivatives::Jpeg2kImage.layer_rates(args.fetch(:layers, 8), args.fetch(:compression, 10))
         tile_size = args.fetch(:tile_size, 1024)
-        tiles_arg = "\{#{tile_size},#{tile_size}\}"
+        tiles_arg = "#{tile_size},#{tile_size}"
         jp2_space_arg = quality == 'gray' ? 'sLUM' : 'sRGB'
 
-        %Q{-rate #{rates_arg} 
+        %Q{-rate #{rates_arg}
             -jp2_space #{jp2_space_arg}
-            -double_buffering 10 
-            -num_threads 4 
-            -no_weights 
-            Clevels=#{levels_arg} 
-            Stiles=#{tiles_arg}
-            Cblk=\{64,64\} 
-            Cuse_sop=yes 
-            Cuse_eph=yes  
-            Corder=RPCL 
-            ORGgen_plt=yes 
+            -double_buffering 10
+            -num_threads 4
+            -no_weights
+            Clevels=#{levels_arg}
+            "Stiles={#{tiles_arg}}"
+            "Cblk={64,64}"
+            Cuse_sop=yes
+            Cuse_eph=yes
+            Corder=RPCL
+            ORGgen_plt=yes
             ORGtparts=R  }.gsub(/\s+/, " ").strip
       end
 


### PR DESCRIPTION
some arguments for the KDU command needed to be escaped properly. This was all working on Ubuntu anyways, however now it also works on RHEL/centos.
