### PR TITLE
load default kdu_recipe from config hash using a symbol rather than a string

### DIFF
--- a/lib/hydra/derivatives/jpeg2k_image.rb
+++ b/lib/hydra/derivatives/jpeg2k_image.rb
@@ -72,7 +72,7 @@ module Hydra
 
       def self.kdu_compress_recipe(args, quality, long_dim)
         if args[:recipe].is_a? Symbol
-          recipe = [args[:recipe].to_s, quality].join('_')
+          recipe = [args[:recipe].to_s, quality].join('_').to_sym
           if Hydra::Derivatives.kdu_compress_recipes.has_key? recipe
             return Hydra::Derivatives.kdu_compress_recipes[recipe]
           else

--- a/spec/fixtures/jpeg2k_config.yml
+++ b/spec/fixtures/jpeg2k_config.yml
@@ -1,13 +1,13 @@
 defaults: &defaults
   jp2_recipes:
     # note that these aren't real recipes, just enough to test configuration options
-    myrecipe_color: >
+    :myrecipe_color: >
       -rate 2.4
-      -jp2_space sRGB 
+      -jp2_space sRGB
       Stiles=\{1024,1024\}
-    myrecipe_grey: >
+    :myrecipe_grey: >
       -rate 2.4
-      -jp2_space sLUM 
+      -jp2_space sLUM
       Stiles=\{1024,1024\}
 
 development:

--- a/spec/units/jpeg2k_spec.rb
+++ b/spec/units/jpeg2k_spec.rb
@@ -13,7 +13,7 @@ describe Hydra::Derivatives::Jpeg2kImage do
     it "calculates the compression rates for each quality layer" do
       compression_num = 10
       layers = 8
-      calc = Hydra::Derivatives::Jpeg2kImage.layer_rates(layers, compression_num) 
+      calc = Hydra::Derivatives::Jpeg2kImage.layer_rates(layers, compression_num)
       expect(calc).to eq("2.4,1.48331273,0.91675694,0.56659885,0.3501847,0.21643059,0.13376427,0.0826726")
     end
 
@@ -28,7 +28,7 @@ describe Hydra::Derivatives::Jpeg2kImage do
     it "can get the recipe from a config file" do
       args = { recipe: :myrecipe }
       r = Hydra::Derivatives::Jpeg2kImage.kdu_compress_recipe(args, 'grey', 7200)
-      expect(r).to eq(@sample_cfg['jp2_recipes']['myrecipe_grey'])
+      expect(r).to eq(@sample_cfg['jp2_recipes'][:myrecipe_grey])
     end
 
     it "can take a recipe as a string" do


### PR DESCRIPTION
With recipe set to :default we always got the following warning: "No JP2 recipe for :default ('default_color') found in configuration. Using best guess."
