### PR TITLE
Fixes 'NameError: uninitialized constant Hydra' on load of railtie

### DIFF
--- a/lib/hydra/derivatives/railtie.rb
+++ b/lib/hydra/derivatives/railtie.rb
@@ -1,7 +1,9 @@
-module Hydra::Derivative
-  class Railtie < Rails::Railtie
-    initializer 'hydra-derivative' do
-      require 'hydra-file_characterization'
+module Hydra
+  module Derivative
+    class Railtie < Rails::Railtie
+      initializer 'hydra-derivative' do
+        require 'hydra-file_characterization'
+      end
     end
   end
 end


### PR DESCRIPTION
I'm not sure how to test this.  [lib/hydra/derivatives.rb#L2](https://github.com/projecthydra-labs/hydra-derivatives/blob/master/lib/hydra/derivatives.rb#L2) was causing `NameError: uninitialized constant Hydra` when I started the rails environment of https://github.com/dtulibrary/missingstuff/blob/fedora4

```
NameError: uninitialized constant Hydra
/Users/matt/.rvm/gems/ruby-2.0.0-p451/bundler/gems/hydra-derivatives-79acfcad3371/lib/hydra/derivatives/railtie.rb:1:in `<top (required)>'
/Users/matt/.rvm/gems/ruby-2.0.0-p451/bundler/gems/hydra-derivatives-79acfcad3371/lib/hydra/derivatives.rb:2:in `require'
/Users/matt/.rvm/gems/ruby-2.0.0-p451/bundler/gems/hydra-derivatives-79acfcad3371/lib/hydra/derivatives.rb:2:in `<top (required)>'
```
