### PR TITLE
Add active_encode support to hydra-derivatives

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/internal/bin/*'
     - 'spec/internal/db/schema.rb'
+    - 'spec/processors/active_encode_spec.rb'
 
 Metrics/LineLength:
   Enabled: false
@@ -39,6 +40,13 @@ Style/IndentationConsistency:
 Style/PredicateName:
   Exclude:
     - spec/services/tempfile_service_spec.rb
+
+Style/RaiseArgs:
+  Enabled: false
+
+Style/HashSyntax:
+  Exclude:
+    - spec/processors/active_encode_spec.rb
 
 RSpec/ExampleWording:
   CustomTransform:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,6 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/internal/bin/*'
     - 'spec/internal/db/schema.rb'
-    - 'spec/processors/active_encode_spec.rb'
 
 Metrics/LineLength:
   Enabled: false
@@ -40,13 +39,6 @@ Style/IndentationConsistency:
 Style/PredicateName:
   Exclude:
     - spec/services/tempfile_service_spec.rb
-
-Style/RaiseArgs:
-  Enabled: false
-
-Style/HashSyntax:
-  Exclude:
-    - spec/processors/active_encode_spec.rb
 
 RSpec/ExampleWording:
   CustomTransform:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Hydra::Derivatives::Processors::Video::Processor.timeout  = 10.minutes
 Hydra::Derivatives::Processors::Document.timeout = 5.minutes
 Hydra::Derivatives::Processors::Audio.timeout = 10.minutes
 Hydra::Derivatives::Processors::Image.timeout = 5.minutes
+Hydra::Derivatives::Processors::ActiveEncode.timeout = 5.minutes
 
 ```
 
@@ -87,6 +88,28 @@ Hydra::Derivatives::Processors::Video::Processor.config.webm.codec = '-vcodec li
 Hydra::Derivatives::Processors::Video::Processor.config.mkv.codec = '-vcodec ffv1'
 Hydra::Derivatives::Processors::Video::Processor.config.jpeg.codec = '-vcodec mjpeg'
 ```
+
+### Configuration for Audio/Video Processing with ActiveEncode
+
+```ruby
+# Set the transcoding engine
+ActiveEncode::Base.engine_adapter = :elastic_transcoder
+
+# Sleep time (in seconds) to poll for status of encoding job
+Hydra::Derivatives.active_encode_poll_time = 10
+
+# If you want to use a different class for the source file service
+Hydra::Derivatives::ActiveEncodeDerivatives.source_file_service = MyCustomSourceFileService
+
+# If you want to use a different class for the output file service
+Hydra::Derivatives::ActiveEncodeDerivatives.output_file_service = MyCustomOutputFileService
+```
+
+Note: Please don't confuse these methods with the similar methods in the parent class:
+`Hydra::Derivatives.source_file_service` and `Hydra::Derivatives.output_file_service`
+
+For additional documentation on using ActiveEncode, see:
+* [Using Amazon Elastic Transcoder](doc/amazon_elastic_transcoder.md)
 
 ### Additional Directives
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Then when you call `obj.create_derivatives` two new files, 'thumbnail' and 'cont
 
 We recommend you run `obj.create_derivatives` in a background worker, because some derivative creation (especially videos) can take a long time.
 
+The ActiveEncode runner provides support for using external video transcoding services like Amazon Elastic Transcoder.  See [ActiveEncode](https://github.com/samvera-labs/active_encode) for details on specific adapters supported.
+
 ## Configuration
 
 ### Retrieving from a basic container in Fedora

--- a/doc/amazon_elastic_transcoder.md
+++ b/doc/amazon_elastic_transcoder.md
@@ -1,0 +1,116 @@
+# Create Audio and Video Derivatives using Amazon Elastic Transcoder
+
+`hydra-derivatives` uses the
+[active\_encode gem](https://github.com/projecthydra-labs/active_encode)
+to allow you to use different encoding services.
+These instructions are for Amazon's Elastic Transcoder service.
+
+## Prerequsites
+
+### Set up the Elastic Transcoder Pipeline
+
+Set up a pipeline on AWS Elastic Transcoder that defines:
+
+* input bucket
+* bucket for transcoded files
+* bucket for thumbnails
+
+### Configure AWS credentials
+
+Optional: If you don't want to pass these values in your ruby code using `Aws.config`, you can set environment variables instead:
+
+* AWS\_ACCESS\_KEY\_ID
+* AWS\_SECRET\_ACCESS\_KEY
+* AWS\_REGION
+
+### Install gems
+
+Add to your `Gemfile`:
+
+* aws-sdk
+
+### Configure initializer
+
+In an initializer file such as `config/initializers/active_encode.rb`, make sure you have the following code:
+
+```ruby
+# Use Amazon's Elastic Transcoder
+ActiveEncode::Base.engine_adapter = :elastic_transcoder
+```
+
+## How to create derivatives (Multiple derivatives per Elastic Transcoder job)
+
+```ruby
+# Access config for AWS
+Aws.config[:access_key_id] = 'put your access key here'
+Aws.config[:secret_access_key] = 'put your secret key here'
+Aws.config[:region] = 'us-east-1'
+
+# The pipeline that I set up in Elastic Transcoder
+pipeline_id = '1490715200916-25b08y'
+
+# The file "sample_data.mp4" has already been uploaded to the input bucket for my pipeline.
+input_file = 'sample_data.mp4'
+
+# Choose a name for the output files
+base_file_name = 'output_file_17'
+
+# Settings for a low-res video derivative using a preset for a 320x240 resolution mp4 file
+low_res_video = { key: "#{base_file_name}.mp4", preset_id: '1351620000001-000061' }
+
+# Settings for a flash video derivative
+flash_video = { key: "#{base_file_name}.flv", preset_id: '1351620000001-100210' }
+
+# Settings to send to the Elastic Transcoder job
+job_settings = { pipeline_id: pipeline_id, output_key_prefix: "active_encode-demo_app/", outputs: [low_res_video, flash_video] }
+
+# Run the encoding
+Hydra::Derivatives::ActiveEncodeDerivatives.create(input_file, outputs: [job_settings])
+
+# Note: Your rails console will not return to the prompt until the encoding is complete,
+# so it might sit there for several minutes with no feedback.
+# Use the AWS console to see the current status of the encoding.
+```
+
+## How to create derivatives (One derivative per Elastic Transcoder job)
+
+If you want to run a separate Elastic Transcoder job for each derivative file, you could do something like this:
+
+```ruby
+# Settings for a low-res video derivative using a preset for a 320x240 resolution mp4 file.
+low_res_preset_id = '1351620000001-000061'
+low_res_output_file = 'output_15.mp4'
+low_res_video = { pipeline_id: pipeline_id, output_key_prefix: "active_encode-demo_app/", outputs: [{ key: low_res_output_file, preset_id: low_res_preset_id }] }
+
+# Settings for a flash video derivative
+flash_preset_id = '1351620000001-100210'
+flash_output_file = 'output_15.flv'
+flash_video = { pipeline_id: pipeline_id, output_key_prefix: "active_encode-demo_app/", outputs: [{ key: flash_output_file, preset_id: flash_preset_id }] }
+
+Hydra::Derivatives::ActiveEncodeDerivatives.create(input_file, outputs: [low_res_video, flash_video])
+```
+
+## How to pass in a ruby object
+
+If you want to pass in an `ActiveFedora::Base` object (or some other record) instead of just a String for the input file name, you need to set the `source` option to specify which method to call on your object to get the file name.  For example:
+
+```ruby
+# Some object that contains the source file name
+class Video
+  attr_accessor :source_file_name
+end
+
+video_record = Video.new
+video_record.source_file_name = 'sample_data.mp4'
+
+Hydra::Derivatives::ActiveEncodeDerivatives.create(video_record, source: :source_file_name, outputs: [low_res_video])
+```
+
+## How to pass in a custom encode class
+
+If you don't want to use the default encode class `::ActiveEncode::Base`, you can pass in `encode_class`:
+
+```ruby
+Hydra::Derivatives::ActiveEncodeDerivatives.create(video_record, encode_class: MyCustomEncode, source: :source_file_name, outputs: [low_res_video])
+```
+

--- a/hydra-derivatives.gemspec
+++ b/hydra-derivatives.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mini_magick', '>= 3.2', '< 5'
   spec.add_dependency 'activesupport', '>= 4.0', '< 6'
   spec.add_dependency 'mime-types', '> 2.0', '< 4.0'
+  spec.add_dependency 'active_encode'
   spec.add_dependency 'deprecation'
 end
 

--- a/hydra-derivatives.gemspec
+++ b/hydra-derivatives.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 4.0', '< 6'
   spec.add_dependency 'mime-types', '> 2.0', '< 4.0'
   spec.add_dependency 'active_encode', '~>0.1'
+  spec.add_dependency 'addressable', '~>2.5'
   spec.add_dependency 'deprecation'
 end
 

--- a/hydra-derivatives.gemspec
+++ b/hydra-derivatives.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mini_magick', '>= 3.2', '< 5'
   spec.add_dependency 'activesupport', '>= 4.0', '< 6'
   spec.add_dependency 'mime-types', '> 2.0', '< 4.0'
-  spec.add_dependency 'active_encode'
+  spec.add_dependency 'active_encode', '~>0.1'
   spec.add_dependency 'deprecation'
 end
 

--- a/lib/hydra/derivatives.rb
+++ b/lib/hydra/derivatives.rb
@@ -8,9 +8,12 @@ module Hydra
     extend Deprecation
     self.deprecation_horizon = "hydra-derivatives 1.0"
 
+    require 'active_encode'
+
     # Runners take a single input and produce one or more outputs
     # The runner typically accomplishes this by using one or more processors
     autoload_under 'runners' do
+      autoload :ActiveEncodeDerivatives
       autoload :AudioDerivatives
       autoload :DocumentDerivatives
       autoload :FullTextExtract
@@ -30,8 +33,10 @@ module Hydra
 
     autoload_under 'services' do
       autoload :RetrieveSourceFileService
+      autoload :RemoteSourceFile
       autoload :PersistOutputFileService
       autoload :PersistBasicContainedOutputFileService
+      autoload :PersistExternalFileOutputFileService
       autoload :TempfileService
       autoload :MimeTypeService
     end
@@ -48,7 +53,7 @@ module Hydra
     end
 
     CONFIG_METHODS = [:ffmpeg_path, :libreoffice_path, :temp_file_base, :fits_path, :kdu_compress_path,
-                      :kdu_compress_recipes, :enable_ffmpeg, :source_file_service, :output_file_service].freeze
+                      :kdu_compress_recipes, :enable_ffmpeg, :source_file_service, :output_file_service, :active_encode_poll_time].freeze
     CONFIG_METHODS.each do |method|
       module_eval <<-RUBY
         def self.#{method}

--- a/lib/hydra/derivatives.rb
+++ b/lib/hydra/derivatives.rb
@@ -8,8 +8,6 @@ module Hydra
     extend Deprecation
     self.deprecation_horizon = "hydra-derivatives 1.0"
 
-    require 'active_encode'
-
     # Runners take a single input and produce one or more outputs
     # The runner typically accomplishes this by using one or more processors
     autoload_under 'runners' do

--- a/lib/hydra/derivatives/config.rb
+++ b/lib/hydra/derivatives/config.rb
@@ -5,7 +5,8 @@ module Hydra
     class Config
       attr_writer :ffmpeg_path, :libreoffice_path, :temp_file_base,
                   :source_file_service, :output_file_service, :fits_path,
-                  :enable_ffmpeg, :kdu_compress_path, :kdu_compress_recipes
+                  :enable_ffmpeg, :kdu_compress_path, :kdu_compress_recipes,
+                  :active_encode_poll_time
 
       def ffmpeg_path
         @ffmpeg_path ||= 'ffmpeg'
@@ -71,6 +72,13 @@ module Hydra
             ORGtparts=R
             "Stiles={1024,1024}" ).gsub(/\s+/, " ").strip
         }
+      end
+
+      # The poll time (in seconds) that the active encode
+      # processor will sleep before it checks the status of an
+      # encoding job.
+      def active_encode_poll_time
+        @active_encode_poll_time ||= 10
       end
     end
   end

--- a/lib/hydra/derivatives/processors.rb
+++ b/lib/hydra/derivatives/processors.rb
@@ -6,6 +6,7 @@ module Hydra::Derivatives
       autoload :Processor
     end
 
+    autoload :ActiveEncode
     autoload :Audio
     autoload :Document
     autoload :Ffmpeg

--- a/lib/hydra/derivatives/processors/active_encode.rb
+++ b/lib/hydra/derivatives/processors/active_encode.rb
@@ -1,0 +1,53 @@
+require 'active_encode'
+
+module Hydra::Derivatives::Processors
+  class ActiveEncodeError < StandardError
+    def initialize(status, source_path, errors = [])
+      msg = "ActiveEncode status was \"#{status}\" for #{source_path}"
+      msg = "#{msg}: #{errors.join(' ; ')}" unless errors.empty?
+      super(msg)
+    end
+  end
+
+  class ActiveEncode < Processor
+    class_attribute :timeout
+    attr_accessor :encode_class
+
+    def initialize(source_path, directives, opts = {})
+      super
+      @encode_class = opts.delete(:encode_class) || ::ActiveEncode::Base
+    end
+
+    def process
+      encode = encode_class.create(source_path, directives)
+      timeout ? wait_for_encode_with_timeout(encode) : wait_for_encode(encode)
+      encode.output.each do |output|
+        output_file_service.call(output, directives)
+      end
+    end
+
+    def wait_for_encode_with_timeout(encode)
+      Timeout.timeout(timeout) { wait_for_encode(encode) }
+    rescue Timeout::Error
+      cleanup_after_timeout(encode)
+    end
+
+    # Wait until the encoding job is finished.  If the status
+    # is anything other than 'completed', raise an error.
+    def wait_for_encode(encode)
+      sleep Hydra::Derivatives.active_encode_poll_time while encode.reload.running?
+      raise ActiveEncodeError.new(encode.state, source_path, encode.errors) unless encode.completed?
+    end
+
+    # After a timeout error, try to cancel the encoding.
+    def cleanup_after_timeout(encode)
+      encode.cancel!
+    rescue => e
+      cancel_error = e
+    ensure
+      msg = "Unable to process ActiveEncode derivative: The command took longer than #{timeout} seconds to execute. Encoding will be cancelled."
+      msg = "#{msg} An error occurred while trying to cancel encoding: #{cancel_error}" if cancel_error
+      raise Hydra::Derivatives::TimeoutError, msg
+    end
+  end
+end

--- a/lib/hydra/derivatives/runners/active_encode_derivatives.rb
+++ b/lib/hydra/derivatives/runners/active_encode_derivatives.rb
@@ -32,6 +32,7 @@ module Hydra::Derivatives
     class << self
       private
 
+        # Build an options hash specifically for the processor isolated from the runner options
         def processor_options(options)
           opts = { output_file_service: output_file_service }
           encode_class = options.delete(:encode_class)

--- a/lib/hydra/derivatives/runners/active_encode_derivatives.rb
+++ b/lib/hydra/derivatives/runners/active_encode_derivatives.rb
@@ -15,13 +15,6 @@ module Hydra::Derivatives
       end
     end
 
-    def self.processor_options(options)
-      opts = { output_file_service: output_file_service }
-      encode_class = options.delete(:encode_class)
-      opts = opts.merge(encode_class: encode_class) if encode_class
-      opts
-    end
-
     # Use the source service configured for this class or default to the remote file service
     def self.source_file_service
       @source_file_service || RemoteSourceFile
@@ -34,6 +27,17 @@ module Hydra::Derivatives
 
     def self.processor_class
       Processors::ActiveEncode
+    end
+
+    class << self
+      private
+
+        def processor_options(options)
+          opts = { output_file_service: output_file_service }
+          encode_class = options.delete(:encode_class)
+          opts = opts.merge(encode_class: encode_class) if encode_class
+          opts
+        end
     end
   end
 end

--- a/lib/hydra/derivatives/runners/active_encode_derivatives.rb
+++ b/lib/hydra/derivatives/runners/active_encode_derivatives.rb
@@ -1,0 +1,39 @@
+module Hydra::Derivatives
+  class ActiveEncodeDerivatives < Runner
+    # @param [String, ActiveFedora::Base] object_or_filename source file name (or path), or an object that has a method that will return the file name
+    # @param [Hash] options options to pass to the encoder
+    # @option options [Symbol] :source a method that can be called on the object to retrieve the source file's name
+    # @option options [Symbol] :encode_class class name of the encode object (usually a subclass of ::ActiveEncode::Base)
+    # @options options [Array] :outputs a list of desired outputs
+    def self.create(object_or_filename, options)
+      processor_opts = processor_options(options)
+      source_file(object_or_filename, options) do |file_name|
+        transform_directives(options.delete(:outputs)).each do |instructions|
+          processor = processor_class.new(file_name, instructions, processor_opts)
+          processor.process
+        end
+      end
+    end
+
+    def self.processor_options(options)
+      opts = { output_file_service: output_file_service }
+      encode_class = options.delete(:encode_class)
+      opts = opts.merge(encode_class: encode_class) if encode_class
+      opts
+    end
+
+    # Use the source service configured for this class or default to the remote file service
+    def self.source_file_service
+      @source_file_service || RemoteSourceFile
+    end
+
+    # Use the output service configured for this class or default to the external file service
+    def self.output_file_service
+      @output_file_service || PersistExternalFileOutputFileService
+    end
+
+    def self.processor_class
+      Processors::ActiveEncode
+    end
+  end
+end

--- a/lib/hydra/derivatives/services/persist_external_file_output_file_service.rb
+++ b/lib/hydra/derivatives/services/persist_external_file_output_file_service.rb
@@ -1,0 +1,18 @@
+module Hydra::Derivatives
+  class PersistExternalFileOutputFileService < PersistOutputFileService
+    # Persists a new file at specified location that points to external content
+    # @param [Hash] output information about the external derivative file
+    # @option output [String] url the location of the external content
+    # @param [Hash] directives directions which can be used to determine where to persist to.
+    # @option directives [String] url This can determine the path of the object.
+    def self.call(output, directives)
+      external_file = ActiveFedora::File.new(directives[:url])
+      # TODO: Replace the following two lines with the shorter call to #external_url once active_fedora/pull/1234 is merged
+      external_file.content = ''
+      external_file.mime_type = "message/external-body; access-type=URL; URL=\"#{output[:url]}\""
+      # external_file.external_url = output[:url]
+      external_file.original_name = URI.parse(output[:url]).path.split('/').last
+      external_file.save
+    end
+  end
+end

--- a/lib/hydra/derivatives/services/persist_external_file_output_file_service.rb
+++ b/lib/hydra/derivatives/services/persist_external_file_output_file_service.rb
@@ -1,3 +1,5 @@
+require 'addressable'
+
 module Hydra::Derivatives
   class PersistExternalFileOutputFileService < PersistOutputFileService
     # Persists a new file at specified location that points to external content
@@ -11,7 +13,7 @@ module Hydra::Derivatives
       external_file.content = ''
       external_file.mime_type = "message/external-body; access-type=URL; URL=\"#{output[:url]}\""
       # external_file.external_url = output[:url]
-      external_file.original_name = URI.parse(output[:url]).path.split('/').last
+      external_file.original_name = Addressable::URI.parse(output[:url]).path.split('/').last
       external_file.save
     end
   end

--- a/lib/hydra/derivatives/services/remote_source_file.rb
+++ b/lib/hydra/derivatives/services/remote_source_file.rb
@@ -6,7 +6,7 @@
 module Hydra::Derivatives
   class RemoteSourceFile
     # Finds the file name of the remote source file.
-    # @param [String, ActiveFedora::Base] String file name, or an object that has a method that will return the file name
+    # @param [String, ActiveFedora::Base] object file name, or an object that has a method that will return the file name
     # @param [Hash] options
     # @option options [Symbol] :source a method that can be called on the object to retrieve the source file's name
     # @yield [String] the file name

--- a/lib/hydra/derivatives/services/remote_source_file.rb
+++ b/lib/hydra/derivatives/services/remote_source_file.rb
@@ -1,0 +1,18 @@
+# For the case where the source file is a remote file, and we
+# don't want to download the file locally, just return the
+# file name or file path (or whatever we need to pass to the
+# encoding service so that it can find the file).
+
+module Hydra::Derivatives
+  class RemoteSourceFile
+    # Finds the file name of the remote source file.
+    # @param [String, ActiveFedora::Base] String file name, or an object that has a method that will return the file name
+    # @param [Hash] options
+    # @option options [Symbol] :source a method that can be called on the object to retrieve the source file's name
+    # @yield [String] the file name
+    def self.call(object, options, &_block)
+      source_name = options.fetch(:source, :to_s)
+      yield(object.send(source_name))
+    end
+  end
+end

--- a/spec/processors/active_encode_spec.rb
+++ b/spec/processors/active_encode_spec.rb
@@ -19,8 +19,8 @@ describe Hydra::Derivatives::Processors::ActiveEncode do
     let(:errors) { [] }
     let(:external_url) { 'http://www.example.com/external/content' }
     let(:output) { [{ url: external_url }] }
-    let(:encode_double) do
-      enc = double('encode',
+    let(:encode_job_double) do
+      enc = double('encode_job',
                    state: state,
                    errors: errors,
                    output: output,

--- a/spec/processors/active_encode_spec.rb
+++ b/spec/processors/active_encode_spec.rb
@@ -22,12 +22,14 @@ describe Hydra::Derivatives::Processors::ActiveEncode do
     let(:external_url) { 'http://www.example.com/external/content' }
     let(:output) { [{ url: external_url }] }
     let(:encode_double) do
-      enc = double('encode', state: state, errors: errors,
+      enc = double('encode',
+                   state: state,
+                   errors: errors,
                    output: output,
-                   'running?': false,
-                   'completed?': completed_status,
-                   'failed?': failed_status,
-                   'cancelled?': cancelled_status)
+                   running?: false,
+                   completed?: completed_status,
+                   failed?: failed_status,
+                   cancelled?: cancelled_status)
       allow(enc).to receive(:reload).and_return(enc)
       enc
     end
@@ -45,8 +47,12 @@ describe Hydra::Derivatives::Processors::ActiveEncode do
 
       let(:completed_status) { true }
       let(:state) { :completed }
-      let(:options) { { encode_class: TestEncode,
-                        output_file_service: output_file_service } }
+      let(:options) do
+        {
+          encode_class: TestEncode,
+          output_file_service: output_file_service
+        }
+      end
 
       it 'uses the configured encode class' do
         expect(TestEncode).to receive(:create).and_return(encode_double)

--- a/spec/processors/active_encode_spec.rb
+++ b/spec/processors/active_encode_spec.rb
@@ -1,0 +1,128 @@
+require 'spec_helper'
+
+describe Hydra::Derivatives::Processors::ActiveEncode do
+  # before { # ActiveEncode::Base.engine_adapter = :test }
+
+  let(:file_path) { File.join(fixture_path, 'videoshort.mp4') }
+  let(:directives) { { url: '12345/derivative' } }
+  let(:output_file_service) { Hydra::Derivatives::PersistExternalFileOutputFileService }
+  let(:options) { { output_file_service: output_file_service } }
+  let(:processor) { described_class.new(file_path, directives, options) }
+
+  describe '#process' do
+    subject { processor.process }
+
+    # Mock out the actual encoding, just pretend that the
+    # encode finished and returned a certain status.
+    let(:failed_status) { false }
+    let(:cancelled_status) { false }
+    let(:completed_status) { false }
+    let(:state) { :completed }
+    let(:errors) { [] }
+    let(:external_url) { 'http://www.example.com/external/content' }
+    let(:output) { [{ url: external_url }] }
+    let(:encode_double) do
+      enc = double('encode', state: state, errors: errors,
+                   output: output,
+                   'running?': false,
+                   'completed?': completed_status,
+                   'failed?': failed_status,
+                   'cancelled?': cancelled_status)
+      allow(enc).to receive(:reload).and_return(enc)
+      enc
+    end
+
+    context 'with a custom encode class' do
+      before do
+        class TestEncode < ::ActiveEncode::Base; end
+
+        # For this spec we don't care what happens with output,
+        # so stub it out to speed up the spec.
+        allow(output_file_service).to receive(:call)
+      end
+
+      after { Object.send(:remove_const, :TestEncode) }
+
+      let(:completed_status) { true }
+      let(:state) { :completed }
+      let(:options) { { encode_class: TestEncode,
+                        output_file_service: output_file_service } }
+
+      it 'uses the configured encode class' do
+        expect(TestEncode).to receive(:create).and_return(encode_double)
+        subject
+      end
+    end
+
+    context 'when the encoding failed' do
+      let(:state) { :failed }
+      let(:failed_status) { true }
+      let(:errors) { ['error 1', 'error 2'] }
+
+      before do
+        # Don't really encode the file during specs
+        allow(::ActiveEncode::Base).to receive(:create).and_return(encode_double)
+      end
+
+      it 'raises an exception' do
+        expect { subject }.to raise_error(Hydra::Derivatives::Processors::ActiveEncodeError, "ActiveEncode status was \"failed\" for #{file_path}: error 1 ; error 2")
+      end
+    end
+
+    context 'when the encoding was cancelled' do
+      let(:state) { :cancelled }
+      let(:cancelled_status) { true }
+
+      before do
+        # Don't really encode the file during specs
+        allow(::ActiveEncode::Base).to receive(:create).and_return(encode_double)
+      end
+
+      it 'raises an exception' do
+        expect { subject }.to raise_error(Hydra::Derivatives::Processors::ActiveEncodeError, "ActiveEncode status was \"cancelled\" for #{file_path}")
+      end
+    end
+
+    context 'when the timeout is set' do
+      before do
+        processor.timeout = 0.01
+        allow(processor).to receive(:wait_for_encode) { sleep 0.1 }
+      end
+
+      it 'raises a timeout exception' do
+        msg = "Unable to process ActiveEncode derivative: The command took longer than 0.01 seconds to execute. Encoding will be cancelled."
+        expect { processor.process }.to raise_error Hydra::Derivatives::TimeoutError, msg
+      end
+    end
+
+    context 'when the timeout is not set' do
+      before do
+        processor.timeout = nil
+        # Don't really encode the file during specs
+        allow(::ActiveEncode::Base).to receive(:create).and_return(encode_double)
+      end
+
+      it 'processes the encoding without a timeout' do
+        expect(processor).to receive(:wait_for_encode_with_timeout).never
+        expect(processor).to receive(:wait_for_encode).once
+        processor.process
+      end
+    end
+
+    context 'when error occurs during timeout cleanup' do
+      let(:error) { StandardError.new('some error message') }
+
+      before do
+        processor.timeout = 0.01
+        allow(processor).to receive(:wait_for_encode) { sleep 0.1 }
+        allow(::ActiveEncode::Base).to receive(:create).and_return(encode_double)
+        allow(encode_double).to receive(:cancel!).and_raise(error)
+      end
+
+      it 'doesnt lose the timeout error, but adds the new error message' do
+        msg = "Unable to process ActiveEncode derivative: The command took longer than 0.01 seconds to execute. Encoding will be cancelled. An error occurred while trying to cancel encoding: some error message"
+        expect { processor.process }.to raise_error Hydra::Derivatives::TimeoutError, msg
+      end
+    end
+  end
+end

--- a/spec/runners/active_encode_derivatives_spec.rb
+++ b/spec/runners/active_encode_derivatives_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe Hydra::Derivatives::ActiveEncodeDerivatives do
+  context '.create' do
+    before do
+      class TestVideo < ActiveFedora::Base
+        attr_accessor :remote_file_name
+      end
+    end
+
+    after { Object.send(:remove_const, :TestVideo) }
+
+    let(:file_path) { 'some/path/to/my_video.mp4' }
+    let(:video_record) { TestVideo.new(remote_file_name: file_path) }
+    let(:options) { { source: :remote_file_name, outputs: [low_res_video] } }
+    let(:low_res_video) { { some_key: 'some options to pass to my encoder service' } }
+    let(:processor) { double('processor') }
+
+    it 'calls the processor with the right arguments' do
+      expect(Hydra::Derivatives::Processors::ActiveEncode).to receive(:new).with(file_path, low_res_video, output_file_service: Hydra::Derivatives::PersistExternalFileOutputFileService).and_return(processor)
+      expect(processor).to receive(:process)
+      described_class.create(video_record, options)
+    end
+
+    context 'with a custom encode class' do
+      before { class TestEncode < ::ActiveEncode::Base; end }
+      after { Object.send(:remove_const, :TestEncode) }
+
+      let(:options) { { encode_class: TestEncode, source: :remote_file_name, outputs: [low_res_video] } }
+
+      it 'calls the processor with the right arguments' do
+        expect(Hydra::Derivatives::Processors::ActiveEncode).to receive(:new).with(file_path, low_res_video, output_file_service: Hydra::Derivatives::PersistExternalFileOutputFileService, encode_class: TestEncode).and_return(processor)
+        expect(processor).to receive(:process)
+        described_class.create(video_record, options)
+      end
+    end
+  end
+end

--- a/spec/services/persist_external_file_output_file_service_spec.rb
+++ b/spec/services/persist_external_file_output_file_service_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Hydra::Derivatives::PersistExternalFileOutputFileService do
+  before do
+    class ExternalDerivativeContainerObject < ActiveFedora::Base
+      has_subresource "external_derivative"
+    end
+  end
+  after do
+    Object.send(:remove_const, :ExternalDerivativeContainerObject)
+  end
+
+  let(:object)            { ExternalDerivativeContainerObject.create }
+  let(:directives)        { { url: "#{object.uri}/external_derivative" } }
+  let(:external_url)      { 'http://www.example.com/external/content' }
+  let(:output)            { { url: external_url } }
+  let(:destination_name)  { 'external_derivative' }
+
+  describe '.call' do
+    it "persists the external file to the specified destination on the given object" do
+      described_class.call(output, directives)
+      expect(object.send(destination_name.to_sym).mime_type).to eq "message/external-body;access-type=URL;url=\"http://www.example.com/external/content\""
+      expect(object.send(destination_name.to_sym).content).to eq ''
+    end
+  end
+end

--- a/spec/services/remote_source_file_spec.rb
+++ b/spec/services/remote_source_file_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+class TestObject < ActiveFedora::Base
+  attr_accessor :source_file_name
+end
+
+describe Hydra::Derivatives::RemoteSourceFile do
+  describe '.call' do
+    let(:file_name) { 'my_source_file.mp4' }
+
+    context 'when you pass in a String file name' do
+      let(:input_obj) { file_name }
+      let(:options) { Hash.new }
+
+      it 'it yields the file name' do
+        expect do |blk|
+          described_class.call(input_obj, options, &blk)
+        end.to yield_with_args(file_name)
+      end
+    end
+
+    context 'when you pass in an ActiveFedora::Base object ' do
+      let(:input_obj) { TestObject.new(source_file_name: file_name) }
+      let(:options) { { source: :source_file_name } }
+
+      it 'it yields the file name' do
+        expect do |blk|
+          described_class.call(input_obj, options, &blk)
+        end.to yield_with_args(file_name)
+      end
+    end
+  end
+end

--- a/spec/units/config_spec.rb
+++ b/spec/units/config_spec.rb
@@ -41,4 +41,10 @@ describe "the configuration" do
     subject.source_file_service = source_file_service
     expect(subject.source_file_service).to eq(source_file_service)
   end
+
+  it "lets you set the poll time for ActiveEncode jobs" do
+    expect(subject.active_encode_poll_time).to eq 10
+    subject.active_encode_poll_time = 15
+    expect(subject.active_encode_poll_time).to eq 15
+  end
 end

--- a/spec/units/derivatives_spec.rb
+++ b/spec/units/derivatives_spec.rb
@@ -53,6 +53,10 @@ describe Hydra::Derivatives do
       subject.kdu_compress_path = '/usr/local/bin/kdu_compress'
       subject.reset_config!
       expect(subject.kdu_compress_path).to eq('kdu_compress')
+
+      subject.active_encode_poll_time = 2
+      subject.reset_config!
+      expect(subject.active_encode_poll_time).to eq 10
     end
   end
 end


### PR DESCRIPTION
The ActiveEncode runner allows using [ActiveEncode](https://github.com/projecthydra-labs/active_encode) within hydra-derivatives to generate derivatives using the adapters supported by ActiveEncode.  Currently Amazon Elastic Transcoder is the only production ready adapter available but prototypes exist for zencoder and [shingoncoder](https://github.com/jcoyne/shingoncoder) (FFmpeg through ActiveJob).  The key differences between ActiveEncode and hydra-derivatives are:

- ActiveEncode can produce multiple derivatives of potentially different formats (video derivatives, thumbnail images) from a single invocation
- ActiveEncode does not necessarily operate on local files
- ActiveEncode returns a url to the derivatives it creates and not a bitstream
- ActiveEncode allows for polling to get updates on its progress

In support of this a source file service and output file service have been added.  The `RemoteServiceFile` takes the `:source` option and calls a method of that name on the source object to determine the source file path or url to send to the processor.  The `PersistExternalFileOutputService` creates an `ActiveFedora::File` with a url to the derivative output instead of storing the actual bit contents of the derivative in Fedora.

Documentation is added for configuring and using the ActiveEncode runner with Amazon Elastic Transcoder which seems like the main use case for users at this point.

Thanks to @val99erie for a lot of this work.