### PR TITLE
Quote file path in soffice command.

### DIFF
--- a/lib/hydra/derivatives/processors/document.rb
+++ b/lib/hydra/derivatives/processors/document.rb
@@ -3,7 +3,7 @@ module Hydra::Derivatives::Processors
     include ShellBasedProcessor
 
     def self.encode(path, format, outdir)
-      execute "#{Hydra::Derivatives.libreoffice_path} --invisible --headless --convert-to #{format} --outdir #{outdir} #{path}"
+      execute "#{Hydra::Derivatives.libreoffice_path} --invisible --headless --convert-to #{format} --outdir #{outdir} \"#{path}\""
     end
 
     # Converts the document to the format specified in the directives hash.

--- a/lib/hydra/derivatives/processors/document.rb
+++ b/lib/hydra/derivatives/processors/document.rb
@@ -3,7 +3,7 @@ module Hydra::Derivatives::Processors
     include ShellBasedProcessor
 
     def self.encode(path, format, outdir)
-      execute "#{Hydra::Derivatives.libreoffice_path} --invisible --headless --convert-to #{format} --outdir #{outdir} \"#{path}\""
+      execute "#{Hydra::Derivatives.libreoffice_path} --invisible --headless --convert-to #{format} --outdir #{outdir} #{Shellwords.escape(path)}"
     end
 
     # Converts the document to the format specified in the directives hash.

--- a/lib/hydra/derivatives/processors/ffmpeg.rb
+++ b/lib/hydra/derivatives/processors/ffmpeg.rb
@@ -14,7 +14,7 @@ module Hydra::Derivatives::Processors
       def encode(path, options, output_file)
         inopts = options[INPUT_OPTIONS] ||= "-y"
         outopts = options[OUTPUT_OPTIONS] ||= ""
-        execute "#{Hydra::Derivatives.ffmpeg_path} #{inopts} -i \"#{path}\" #{outopts} #{output_file}"
+        execute "#{Hydra::Derivatives.ffmpeg_path} #{inopts} -i #{Shellwords.escape(path)} #{outopts} #{output_file}"
       end
     end
   end

--- a/lib/hydra/derivatives/processors/jpeg2k_image.rb
+++ b/lib/hydra/derivatives/processors/jpeg2k_image.rb
@@ -75,7 +75,7 @@ module Hydra::Derivatives::Processors
 
       def encode(path, recipe, output_file)
         kdu_compress = Hydra::Derivatives.kdu_compress_path
-        execute "#{kdu_compress} -quiet -i #{path} -o #{output_file} #{recipe}"
+        execute "#{kdu_compress} -quiet -i #{Shellwords.escape(path)} -o #{output_file} #{recipe}"
       end
 
       def tmp_file(ext)


### PR DESCRIPTION
Fix for #163 

Quote the file path to prevent a bash syntax error.