### PR TITLE
Use activeFedora current solr connection for the extract uri

### DIFF
--- a/lib/hydra/derivatives/processors/full_text.rb
+++ b/lib/hydra/derivatives/processors/full_text.rb
@@ -50,11 +50,12 @@ module Hydra::Derivatives::Processors
 
       # @returns [URI] path to the extract service
       def uri
-        @uri ||= URI("#{connection_url}/update/extract?extractOnly=true&wt=json&extractFormat=text")
+        @uri ||= connection_url + 'update/extract?extractOnly=true&wt=json&extractFormat=text'
       end
 
+      # @returns [URI] path to the solr collection
       def connection_url
-        ActiveFedora.solr_config[:url]
+        ActiveFedora::SolrService.instance.conn.uri
       end
   end
 end

--- a/spec/processors/full_text_spec.rb
+++ b/spec/processors/full_text_spec.rb
@@ -46,10 +46,15 @@ describe Hydra::Derivatives::Processors::FullText do
 
   describe "uri" do
     subject { processor.send(:uri) }
+    let(:root) { URI('http://example.com/solr/myCollection/') }
+
+    before do
+      allow(ActiveFedora::SolrService.instance.conn).to receive(:uri).and_return(root)
+    end
 
     it "points at the extraction service" do
       expect(subject).to be_kind_of URI
-      expect(subject.to_s).to end_with '/update/extract?extractOnly=true&wt=json&extractFormat=text'
+      expect(subject.to_s).to eq 'http://example.com/solr/myCollection/update/extract?extractOnly=true&wt=json&extractFormat=text'
     end
   end
 end


### PR DESCRIPTION
Previously we were using the value of the yaml configuration, which is
the default way to initialize a connection, but not the only way. It is
also possible for the connection to be initialized programatically.
This is what hyku is doing to support multiple tenants each with their
own solr collection.

See https://github.com/samvera-labs/hyku/issues/1275