### PR TITLE
Compensate for Net::HTTP disrespecting Content-Type encoding

### DIFF
--- a/lib/hydra/derivatives/processors/full_text.rb
+++ b/lib/hydra/derivatives/processors/full_text.rb
@@ -27,6 +27,9 @@ module Hydra::Derivatives::Processors
         raise "Solr Extract service was unsuccessful. '#{uri}' returned code #{resp.code} for #{source_path}\n#{resp.body}" unless resp.code == '200'
         file_content.rewind if file_content.respond_to?(:rewind)
 
+        if resp.type_params['charset']
+          resp.body.force_encoding(resp.type_params['charset'])
+        end
         resp.body
       end
 

--- a/spec/processors/full_text_spec.rb
+++ b/spec/processors/full_text_spec.rb
@@ -28,10 +28,20 @@ describe Hydra::Derivatives::Processors::FullText do
     end
 
     context "that is successful" do
-      let(:resp) { double(code: '200', body: response_body) }
+      let(:resp) { double(code: '200', type_params: {}, body: response_body) }
       it "calls the extraction service" do
         expect(request).to receive(:post).with('http://example.com:99/solr/update', String, "Content-Type" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Content-Length" => "24244").and_return(resp)
         expect(subject).to eq response_body
+      end
+    end
+
+    context "that is successful with UTF-8 content" do
+      let(:response_utf8)  { "returned by “Solr”" }
+      let(:response_ascii) { response_utf8.dup.force_encoding("ASCII-8BIT") }
+      let(:resp)           { double(code: '200', type_params: { "charset" => "UTF-8" }, body: response_ascii) }
+      it "calls the extraction service" do
+        expect(request).to receive(:post).with('http://example.com:99/solr/update', String, "Content-Type" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Content-Length" => "24244").and_return(resp)
+        expect(subject).to eq response_utf8
       end
     end
 


### PR DESCRIPTION
Per https://bugs.ruby-lang.org/issues/2567, Net::HTTP has a known issue where `response.body` is always `ASCII-8BIT` encoded. The issue has been debated for almost 8 years now, with no resolution in sight. Since Faraday doesn't compensate for it, the only thing to do is use `force_encoding` if the `Content-Type|charset` subfield is present.