### PR TITLE
Update rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,42 +3,35 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   DisplayCopNames: true
-  Include:
-    - '**/Rakefile'
   Exclude:
     - 'vendor/**/*'
     - 'spec/internal/bin/*'
     - 'spec/internal/db/schema.rb'
+    - Gemfile
+    - hydra-derivatives.gemspec
+    - Rakefile
+
+Layout/IndentationConsistency:
+  EnforcedStyle: rails
+
+Metrics/AbcSize:
+  Max: 42
+  Exclude:
+    - lib/hydra/derivatives/processors/document.rb
+    - lib/hydra/derivatives/processors/full_text.rb
+    - lib/hydra/derivatives/processors/jpeg2k_image.rb
+    - lib/hydra/derivatives/processors/shell_based_processor.rb
+    - lib/hydra/derivatives/services/persist_basic_contained_output_file_service.rb
+    - lib/hydra/derivatives/services/tempfile_service.rb
+
+Metrics/BlockLength:
+  Max: 320
 
 Metrics/LineLength:
   Enabled: false
 
-Style/CollectionMethods:
-  PreferredMethods:
-    collect: 'map'
-    collect!: 'map!'
-    inject: 'reduce'
-    detect: 'find'
-    find_all: 'select'
-
-Style/ClassAndModuleChildren:
-  Enabled: false
-
-Style/Documentation:
-  Enabled: false
-
-Style/StringLiterals:
-  Enabled: false
-
-Style/SignalException:
-  Enabled: false
-
-Style/IndentationConsistency:
-  EnforcedStyle: rails
-
-Style/PredicateName:
-  Exclude:
-    - spec/services/tempfile_service_spec.rb
+RSpec/ExampleLength:
+  Max: 10
 
 RSpec/ExampleWording:
   CustomTransform:
@@ -52,15 +45,41 @@ RSpec/ExampleWording:
 RSpec/FilePath:
   Enabled: false
 
+RSpec/HookArgument:
+  Exclude:
+    - spec/spec_helper.rb
+
 RSpec/InstanceVariable:
   Enabled: false
 
-RSpec/DescribeClass:
-  Exclude:
-    - spec/units/config_spec.rb
-    - spec/units/transcoding_spec.rb
+RSpec/MessageSpies:
+  Enabled: false
 
-RSpec/AnyInstance:
-  Exclude:
-    - spec/processors/image_spec.rb
-    - spec/units/transcoding_spec.rb
+RSpec/MultipleExpectations:
+  Max: 10
+
+RSpec/NamedSubject:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Max: 4
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/CollectionMethods:
+  PreferredMethods:
+    collect: 'map'
+    collect!: 'map!'
+    inject: 'reduce'
+    detect: 'find'
+    find_all: 'select'
+
+Style/Documentation:
+  Enabled: false
+
+Style/SignalException:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,5 +1,14 @@
 # List of files that we ought to fix based on what Rubocop is complaining about them
 
+Layout/SpaceBeforeBlockBraces:
+  Exclude:
+    - lib/hydra/derivatives/processors/jpeg2k_image.rb
+    - lib/hydra/derivatives/processors/shell_based_processor.rb
+
+Metrics/ClassLength:
+  Exclude:
+    - lib/hydra/derivatives/processors/jpeg2k_image.rb
+
 Metrics/CyclomaticComplexity:
   Exclude:
     - spec/units/transcoding_spec.rb
@@ -12,18 +21,42 @@ Metrics/MethodLength:
     - lib/hydra/derivatives/processors/shell_based_processor.rb
     - lib/hydra/derivatives/processors/video/processor.rb
     - lib/hydra/derivatives/services/tempfile_service.rb
+    - spec/**/*.rb
+
+Naming/PredicateName:
+  Exclude:
+    - spec/services/tempfile_service_spec.rb
+
+RSpec/AnyInstance:
+  Exclude:
+    - spec/processors/image_spec.rb
     - spec/units/transcoding_spec.rb
 
-Metrics/ClassLength:
+RSpec/BeforeAfterAll:
   Exclude:
-    - lib/hydra/derivatives/processors/jpeg2k_image.rb
+    - spec/**/*.rb
 
-Metrics/AbcSize:
+RSpec/DescribeClass:
   Exclude:
-    - lib/hydra/derivatives/processors/document.rb
-    - lib/hydra/derivatives/processors/full_text.rb
-    - lib/hydra/derivatives/processors/jpeg2k_image.rb
-    - lib/hydra/derivatives/processors/shell_based_processor.rb
-    - lib/hydra/derivatives/services/persist_basic_contained_output_file_service.rb
-    - lib/hydra/derivatives/services/tempfile_service.rb
+    - spec/units/config_spec.rb
     - spec/units/transcoding_spec.rb
+
+RSpec/PredicateMatcher:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/ReturnFromStub:
+  Exclude:
+    - spec/processors/jpeg2k_spec.rb
+
+RSpec/SubjectStub:
+  Exclude:
+    - spec/**/*.rb
+
+RSpec/VerifiedDoubles:
+  Exclude:
+    - spec/processors/full_text_spec.rb
+
+Style/EvalWithLocation:
+  Exclude:
+    - lib/hydra/derivatives.rb

--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,9 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'simplecov'
-  gem 'coveralls'
   gem 'byebug' unless ENV['TRAVIS']
-  gem 'rubocop', '~> 0.37.2', require: false
+  gem 'coveralls'
+  gem 'rubocop', '~> 0.52.0', require: false
   gem 'rubocop-rspec', require: false
+  gem 'simplecov'
 end

--- a/hydra-derivatives.gemspec
+++ b/hydra-derivatives.gemspec
@@ -1,14 +1,12 @@
-# coding: utf-8
 version = File.read(File.expand_path("../VERSION", __FILE__)).strip
-
 
 Gem::Specification.new do |spec|
   spec.name          = "hydra-derivatives"
   spec.version       = version
   spec.authors       = ["Justin Coyne"]
   spec.email         = ["justin@curationexperts.com"]
-  spec.description   = %q{Derivative generation plugin for hydra}
-  spec.summary       = %q{Derivative generation plugin for hydra}
+  spec.description   = "Derivative generation plugin for hydra"
+  spec.summary       = "Derivative generation plugin for hydra"
   spec.license       = "APACHE2"
   spec.homepage      = "https://github.com/projecthydra/hydra-derivatives"
 
@@ -18,16 +16,16 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'fcrepo_wrapper', '~> 0.2'
   spec.add_development_dependency 'rake', '~> 10.1'
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency "solr_wrapper", "~> 0.4"
-  spec.add_development_dependency 'fcrepo_wrapper', '~> 0.2'
 
   spec.add_dependency 'active-fedora', '>= 11.3.1', '< 13'
-  spec.add_dependency 'mini_magick', '>= 3.2', '< 5'
-  spec.add_dependency 'activesupport', '>= 4.0', '< 6'
-  spec.add_dependency 'mime-types', '> 2.0', '< 4.0'
   spec.add_dependency 'active_encode', '~>0.1'
+  spec.add_dependency 'activesupport', '>= 4.0', '< 6'
   spec.add_dependency 'addressable', '~>2.5'
   spec.add_dependency 'deprecation'
+  spec.add_dependency 'mime-types', '> 2.0', '< 4.0'
+  spec.add_dependency 'mini_magick', '>= 3.2', '< 5'
 end

--- a/lib/hydra/derivatives.rb
+++ b/lib/hydra/derivatives.rb
@@ -50,8 +50,8 @@ module Hydra
       @config = Config.new
     end
 
-    CONFIG_METHODS = [:ffmpeg_path, :libreoffice_path, :temp_file_base, :fits_path, :kdu_compress_path,
-                      :kdu_compress_recipes, :enable_ffmpeg, :source_file_service, :output_file_service, :active_encode_poll_time].freeze
+    CONFIG_METHODS = %i[ffmpeg_path libreoffice_path temp_file_base fits_path kdu_compress_path
+                        kdu_compress_recipes enable_ffmpeg source_file_service output_file_service active_encode_poll_time].freeze
     CONFIG_METHODS.each do |method|
       module_eval <<-RUBY
         def self.#{method}

--- a/lib/hydra/derivatives/audio_encoder.rb
+++ b/lib/hydra/derivatives/audio_encoder.rb
@@ -4,7 +4,7 @@ module Hydra::Derivatives
   class AudioEncoder
     def initialize
       @ffmpeg_output = Open3.capture3('ffmpeg -codecs').to_s
-    rescue
+    rescue StandardError
       Logger.warn('Unable to find ffmpeg')
       @ffmpeg_output = ""
     end

--- a/lib/hydra/derivatives/logger.rb
+++ b/lib/hydra/derivatives/logger.rb
@@ -3,12 +3,16 @@ module Hydra::Derivatives
     class << self
       def method_missing(method_name, *arguments, &block)
         logger.send(method_name, *arguments, &block)
-      rescue
+      rescue StandardError
         super
       end
 
       def respond_to?(method_name, _include_private = false)
         logger.respond_to? method_name
+      end
+
+      def respond_to_missing?(method_name, _include_private = false)
+        logger.respond_to_missing? method_name
       end
 
       private

--- a/lib/hydra/derivatives/processors/active_encode.rb
+++ b/lib/hydra/derivatives/processors/active_encode.rb
@@ -45,7 +45,7 @@ module Hydra::Derivatives::Processors
       # After a timeout error, try to cancel the encoding.
       def cleanup_after_timeout
         encode_job.cancel!
-      rescue => e
+      rescue StandardError => e
         cancel_error = e
       ensure
         msg = "Unable to process ActiveEncode derivative: The command took longer than #{timeout} seconds to execute. Encoding will be cancelled."

--- a/lib/hydra/derivatives/processors/jpeg2k_image.rb
+++ b/lib/hydra/derivatives/processors/jpeg2k_image.rb
@@ -17,16 +17,13 @@ module Hydra::Derivatives::Processors
       def kdu_compress_recipe(args, quality, long_dim)
         if args[:recipe].is_a? Symbol
           recipe = [args[:recipe].to_s, quality].join('_').to_sym
-          if Hydra::Derivatives.kdu_compress_recipes.key? recipe
-            return Hydra::Derivatives.kdu_compress_recipes[recipe]
-          else
-            ActiveFedora::Base.logger.warn "No JP2 recipe for :#{args[:recipe]} ('#{recipe}') found in configuration. Using best guess."
-            return calculate_recipe(args, quality, long_dim)
-          end
+          return Hydra::Derivatives.kdu_compress_recipes[recipe] if Hydra::Derivatives.kdu_compress_recipes.key? recipe
+          ActiveFedora::Base.logger.warn "No JP2 recipe for :#{args[:recipe]} ('#{recipe}') found in configuration. Using best guess."
+          calculate_recipe(args, quality, long_dim)
         elsif args[:recipe].is_a? String
-          return args[:recipe]
+          args[:recipe]
         else
-          return calculate_recipe(args, quality, long_dim)
+          calculate_recipe(args, quality, long_dim)
         end
       end
 

--- a/lib/hydra/derivatives/services/capability_service.rb
+++ b/lib/hydra/derivatives/services/capability_service.rb
@@ -5,7 +5,7 @@ module Hydra::Derivatives
     attr_accessor :ffmpeg_output
     def capture_output
       @ffmpeg_output = Open3.capture3('ffmpeg -codecs').to_s
-    rescue
+    rescue StandardError
       Logger.warn('Unable to find ffmpeg')
       @ffmpeg_output = ""
     end

--- a/spec/processors/active_encode_spec.rb
+++ b/spec/processors/active_encode_spec.rb
@@ -20,14 +20,14 @@ describe Hydra::Derivatives::Processors::ActiveEncode do
     let(:external_url) { 'http://www.example.com/external/content' }
     let(:output) { [{ url: external_url }] }
     let(:encode_job_double) do
-      enc = double('encode_job',
-                   state: state,
-                   errors: errors,
-                   output: output,
-                   running?: false,
-                   completed?: completed_status,
-                   failed?: failed_status,
-                   cancelled?: cancelled_status)
+      enc = instance_double('encode_job',
+                            state: state,
+                            errors: errors,
+                            output: output,
+                            running?: false,
+                            completed?: completed_status,
+                            failed?: failed_status,
+                            cancelled?: cancelled_status)
       allow(enc).to receive(:reload).and_return(enc)
       enc
     end

--- a/spec/processors/document_spec.rb
+++ b/spec/processors/document_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 describe Hydra::Derivatives::Processors::Document do
+  subject { described_class.new(source_path, directives) }
+
   let(:source_path)    { File.join(fixture_path, "test.doc") }
   let(:output_service) { Hydra::Derivatives::PersistBasicContainedOutputFileService }
 
   before { allow(subject).to receive(:converted_file).and_return(converted_file) }
-
-  subject { described_class.new(source_path, directives) }
 
   describe "#encode_file" do
     context "when converting to jpg" do

--- a/spec/processors/full_text_spec.rb
+++ b/spec/processors/full_text_spec.rb
@@ -16,19 +16,20 @@ describe Hydra::Derivatives::Processors::FullText do
   end
 
   describe "fetch" do
+    subject { processor.send(:fetch) }
+
     let(:request)       { double }
     let(:response_body) { 'returned by Solr' }
     let(:uri)           { URI('https://example.com:99/solr/update') }
-
-    subject { processor.send(:fetch) }
 
     before do
       allow(processor).to receive(:uri).and_return(uri)
       allow(Net::HTTP).to receive(:new).with('example.com', 99).and_return(request)
     end
 
-    context "that is successful" do
+    context "when that is successful" do
       let(:resp) { double(code: '200', type_params: {}, body: response_body) }
+
       it "calls the extraction service" do
         expect(processor).to receive(:check_for_ssl)
         expect(request).to receive(:post).with('https://example.com:99/solr/update', String, "Content-Type" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Content-Length" => "24244").and_return(resp)
@@ -36,10 +37,11 @@ describe Hydra::Derivatives::Processors::FullText do
       end
     end
 
-    context "that is successful with UTF-8 content" do
+    context "when that is successful with UTF-8 content" do
       let(:response_utf8)  { "returned by “Solr”" }
       let(:response_ascii) { response_utf8.dup.force_encoding("ASCII-8BIT") }
       let(:resp)           { double(code: '200', type_params: { "charset" => "UTF-8" }, body: response_ascii) }
+
       it "calls the extraction service" do
         expect(processor).to receive(:check_for_ssl)
         expect(request).to receive(:post).with('https://example.com:99/solr/update', String, "Content-Type" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Content-Length" => "24244").and_return(resp)
@@ -47,8 +49,9 @@ describe Hydra::Derivatives::Processors::FullText do
       end
     end
 
-    context "that fails" do
+    context "when that fails" do
       let(:resp) { double(code: '500', body: response_body) }
+
       it "raises an error" do
         expect(processor).to receive(:check_for_ssl)
         expect(request).to receive(:post).with('https://example.com:99/solr/update', String, "Content-Type" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Content-Length" => "24244").and_return(resp)
@@ -59,6 +62,7 @@ describe Hydra::Derivatives::Processors::FullText do
 
   describe "uri" do
     subject { processor.send(:uri) }
+
     let(:root) { URI('https://example.com/solr/myCollection/') }
 
     before do

--- a/spec/processors/image_spec.rb
+++ b/spec/processors/image_spec.rb
@@ -1,20 +1,21 @@
 require 'spec_helper'
 
 describe Hydra::Derivatives::Processors::Image do
-  let(:file_name) { "file_name" }
   subject { described_class.new(file_name, directives) }
+
+  let(:file_name) { "file_name" }
 
   context "when arguments are passed as a hash" do
     before { allow(subject).to receive(:load_image_transformer).and_return(mock_image) }
 
     context "with a multi-page pdf source file" do
-      let(:first_page)  { double("MockPage") }
-      let(:second_page) { double("MockPage") }
-      let(:mock_image)  { double("MockImageOfPdf", layers: [first_page, second_page]) }
+      let(:first_page)  { instance_double("MockPage") }
+      let(:second_page) { instance_double("MockPage") }
+      let(:mock_image)  { instance_double("MockImageOfPdf", layers: [first_page, second_page]) }
 
       before { allow(mock_image).to receive(:type).and_return("PDF") }
 
-      context "by default" do
+      context "when default" do
         let(:directives) { { label: :thumb, size: "200x300>", format: 'png', quality: 75 } }
 
         it "uses the first page" do
@@ -52,8 +53,8 @@ describe Hydra::Derivatives::Processors::Image do
     context "with an image source file" do
       before { allow(mock_image).to receive(:type).and_return("JPEG") }
 
-      context "by default" do
-        let(:mock_image) { double("MockImage") }
+      context "when default" do
+        let(:mock_image) { instance_double("MockImage") }
         let(:directives) { { label: :thumb, size: "200x300>", format: 'png', quality: 75 } }
 
         it "uses the image file" do
@@ -68,9 +69,9 @@ describe Hydra::Derivatives::Processors::Image do
       end
 
       context "when specifying a layer" do
-        let(:first_layer)  { double("MockPage") }
-        let(:second_layer) { double("MockPage") }
-        let(:mock_image)   { double("MockImage", layers: [first_layer, second_layer]) }
+        let(:first_layer)  { instance_double("MockPage") }
+        let(:second_layer) { instance_double("MockPage") }
+        let(:mock_image)   { instance_double("MockImage", layers: [first_layer, second_layer]) }
         let(:directives)   { { label: :thumb, size: "200x300>", format: 'png', quality: 75, layer: 1 } }
 
         it "uses the layer" do
@@ -113,6 +114,7 @@ describe Hydra::Derivatives::Processors::Image do
 
     context "when running the complete command", requires_imagemagick: true do
       let(:file_name) { File.join(fixture_path, "test.tif") }
+
       it "converts the image" do
         expect(Hydra::Derivatives::PersistBasicContainedOutputFileService).to receive(:call).with(kind_of(StringIO), directives)
         subject.process

--- a/spec/processors/processor_spec.rb
+++ b/spec/processors/processor_spec.rb
@@ -1,18 +1,18 @@
 require 'spec_helper'
 
 describe Hydra::Derivatives::Processors::Processor do
+  subject { described_class.new(file_path, directives) }
+
   let(:object)        { "Fake Object" }
   let(:source_name)   { 'content' }
   let(:directives)    { { thumb: "100x100>" } }
   let(:file_path)     { double }
 
-  subject { described_class.new(file_path, directives) }
-
   describe "output_file_service" do
     let(:custom_output_file_service) { "fake service" }
     let(:another_custom_output_file_service) { "another fake service" }
 
-    context "as a global configuration setting" do
+    context "with a global configuration setting" do
       before do
         allow(Hydra::Derivatives).to receive(:output_file_service).and_return(custom_output_file_service)
       end
@@ -21,7 +21,7 @@ describe Hydra::Derivatives::Processors::Processor do
       end
     end
 
-    context "as an instance level configuration setting" do
+    context "with an instance level configuration setting" do
       subject do
         described_class.new('/opt/derivatives/foo.mp4', directives,
                             output_file_service: another_custom_output_file_service)

--- a/spec/processors/video_spec.rb
+++ b/spec/processors/video_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
 
 describe Hydra::Derivatives::Processors::Video::Processor do
-  let(:file_name) { 'foo/bar.mov' }
   subject { described_class.new(file_name, directives) }
+
+  let(:file_name) { 'foo/bar.mov' }
 
   describe ".config" do
     before do
@@ -20,7 +21,7 @@ describe Hydra::Derivatives::Processors::Video::Processor do
   end
 
   context "when arguments are passed as a hash" do
-    context "and a video format is requested" do
+    context "when a video format is requested" do
       let(:directives) { { label: :thumb, format: 'webm', url: 'http://localhost:8983/fedora/rest/dev/1234/thumbnail' } }
 
       it "creates a fedora resource and infers the name" do
@@ -29,8 +30,9 @@ describe Hydra::Derivatives::Processors::Video::Processor do
       end
     end
 
-    context "and jpg is requested" do
+    context "when a jpg is requested" do
       let(:directives) { { label: :thumb, format: 'jpg', url: 'http://localhost:8983/fedora/rest/dev/1234/thumbnail' } }
+
       it "creates a fedora resource and infers the name" do
         expect(subject).to receive(:encode_file).with("jpg", output_options: "-s 320x240 -vcodec mjpeg -vframes 1 -an -f rawvideo", input_options: " -itsoffset -2")
         subject.process

--- a/spec/runners/active_encode_derivatives_spec.rb
+++ b/spec/runners/active_encode_derivatives_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Hydra::Derivatives::ActiveEncodeDerivatives do
-  context '.create' do
+  describe '.create' do
     before do
       class TestVideo < ActiveFedora::Base
         attr_accessor :remote_file_name
@@ -14,7 +14,7 @@ describe Hydra::Derivatives::ActiveEncodeDerivatives do
     let(:video_record) { TestVideo.new(remote_file_name: file_path) }
     let(:options) { { source: :remote_file_name, outputs: [low_res_video] } }
     let(:low_res_video) { { some_key: 'some options to pass to my encoder service' } }
-    let(:processor) { double('processor') }
+    let(:processor) { instance_double('processor') }
 
     it 'calls the processor with the right arguments' do
       expect(Hydra::Derivatives::Processors::ActiveEncode).to receive(:new).with(file_path, low_res_video, output_file_service: Hydra::Derivatives::PersistExternalFileOutputFileService).and_return(processor)

--- a/spec/services/audio_derivatives_spec.rb
+++ b/spec/services/audio_derivatives_spec.rb
@@ -31,7 +31,7 @@ describe Hydra::Derivatives::AudioDerivatives do
     context "with an object" do
       let(:object)      { "Fake Object" }
       let(:source_name) { :content }
-      let(:file)        { double("the file") }
+      let(:file)        { instance_double("the file") }
 
       before do
         allow(object).to receive(:original_file).and_return(file)

--- a/spec/services/persist_basic_contained_output_file_service_spec.rb
+++ b/spec/services/persist_basic_contained_output_file_service_spec.rb
@@ -19,7 +19,8 @@ describe Hydra::Derivatives::PersistBasicContainedOutputFileService do
     let(:object) { BasicContainerObject.create }
     let(:content) { StringIO.new("fake file content") }
     let(:resource) { object.public_send(destination_name.to_sym) }
-    context "and the content is a stream" do
+
+    context "when the content is a stream" do
       it "persists the file to the specified destination on the given object" do
         described_class.call(content, format: 'jpg', url: "#{object.uri}/the_derivative_name")
         expect(resource.content).to start_with("fake file content")
@@ -28,8 +29,9 @@ describe Hydra::Derivatives::PersistBasicContainedOutputFileService do
       end
     end
 
-    context "and content is a string" do
+    context "when the content is a string" do
       let(:content) { "fake file content - ÅÄÖ" }
+
       it "persists the file to the specified destination on the given object" do
         described_class.call(content, format: 'txt', url: "#{object.uri}/the_derivative_name")
         expect(resource.content).to eq("fake file content - ÅÄÖ")

--- a/spec/services/remote_source_file_spec.rb
+++ b/spec/services/remote_source_file_spec.rb
@@ -10,9 +10,9 @@ describe Hydra::Derivatives::RemoteSourceFile do
 
     context 'when you pass in a String file name' do
       let(:input_obj) { file_name }
-      let(:options) { Hash.new }
+      let(:options) { {} }
 
-      it 'it yields the file name' do
+      it 'yields the file name' do
         expect do |blk|
           described_class.call(input_obj, options, &blk)
         end.to yield_with_args(file_name)
@@ -23,7 +23,7 @@ describe Hydra::Derivatives::RemoteSourceFile do
       let(:input_obj) { TestObject.new(source_file_name: file_name) }
       let(:options) { { source: :source_file_name } }
 
-      it 'it yields the file name' do
+      it 'yields the file name' do
         expect do |blk|
           described_class.call(input_obj, options, &blk)
         end.to yield_with_args(file_name)

--- a/spec/services/tempfile_service_spec.rb
+++ b/spec/services/tempfile_service_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Hydra::Derivatives::TempfileService do
+  subject { described_class.new(file) }
+
   let(:class_with_metadata_extraction) do
     Class.new do
       attr_reader :content, :mime_type, :uri
@@ -21,8 +23,7 @@ describe Hydra::Derivatives::TempfileService do
 
   let(:file) { class_with_metadata_extraction.new(initialization_options) }
 
-  subject { described_class.new(file) }
-  context '#tempfile' do
+  describe '#tempfile' do
     it 'has a method called to_tempfile' do
       expect { |b| subject.tempfile(&b) }.to yield_with_args(Tempfile)
     end

--- a/spec/units/config_spec.rb
+++ b/spec/units/config_spec.rb
@@ -31,13 +31,13 @@ describe "the configuration" do
   end
 
   it "lets you set a custom output file service" do
-    output_file_service = double("MyOutputFileService")
+    output_file_service = instance_double("MyOutputFileService")
     subject.output_file_service = output_file_service
     expect(subject.output_file_service).to eq(output_file_service)
   end
 
   it "lets you set a custom source file service" do
-    source_file_service = double("MyRetriveSourceFileService")
+    source_file_service = instance_double("MyRetriveSourceFileService")
     subject.source_file_service = source_file_service
     expect(subject.source_file_service).to eq(source_file_service)
   end

--- a/spec/units/derivatives_spec.rb
+++ b/spec/units/derivatives_spec.rb
@@ -12,18 +12,20 @@ describe Hydra::Derivatives do
   describe "source_file_service" do
     before  { subject.source_file_service = custom_source_file_service }
 
-    context "as a global configuration setting" do
-      let(:custom_source_file_service) { "fake service" }
+    context "with a global configuration setting" do
       subject { CustomFile }
+
+      let(:custom_source_file_service) { "fake service" }
 
       it "utilizes the default source file service" do
         expect(subject.source_file_service).to eq(custom_source_file_service)
       end
     end
 
-    context "as an instance level configuration setting" do
-      let(:custom_source_file_service) { "another fake service" }
+    context "with an instance level configuration setting" do
       subject { CustomFile.new }
+
+      let(:custom_source_file_service) { "another fake service" }
 
       it "accepts a custom source file service as an option" do
         expect(subject.source_file_service).to eq(custom_source_file_service)

--- a/spec/units/io_decorator_spec.rb
+++ b/spec/units/io_decorator_spec.rb
@@ -4,34 +4,40 @@ require 'stringio'
 describe Hydra::Derivatives::IoDecorator do
   let(:file) { StringIO.new('hello') }
 
-  context "one argument" do
+  context "with one argument" do
     let(:decorator) { described_class.new(file) }
+
     describe "#read" do
       subject { decorator.read }
+
       it { is_expected.to eq 'hello' }
     end
   end
 
-  context "three arguments" do
+  context "with three arguments" do
     let(:decorator) { described_class.new(file, 'text/plain', 'help.txt') }
 
     describe "#read" do
       subject { decorator.read }
+
       it { is_expected.to eq 'hello' }
     end
 
     describe "mime_type" do
       subject { decorator.mime_type }
+
       it { is_expected.to eq 'text/plain' }
     end
 
     describe "original_filename" do
       subject { decorator.original_filename }
+
       it { is_expected.to eq 'help.txt' }
     end
 
     describe "original_name" do
       subject { decorator.original_name }
+
       before { allow(Deprecation).to receive(:warn) }
       it { is_expected.to eq 'help.txt' }
     end

--- a/spec/units/logger_spec.rb
+++ b/spec/units/logger_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Hydra::Derivatives::Logger do
   context "with log levels" do
-    let(:levels) { %w(unknown fatal error warn info debug) }
+    let(:levels) { %w[unknown fatal error warn info debug] }
 
     it "responds successfully" do
       levels.each do |level|

--- a/spec/units/transcoding_spec.rb
+++ b/spec/units/transcoding_spec.rb
@@ -17,56 +17,64 @@ describe "Transcoding" do
           AudioDerivatives.create(self, source: :original_file,
                                         outputs: [
                                           { label: :mp3, format: 'mp3', url: "#{uri}/original_file_mp3" },
-                                          { label: :ogg, format: 'ogg', url: "#{uri}/original_file_ogg" }])
+                                          { label: :ogg, format: 'ogg', url: "#{uri}/original_file_ogg" }
+                                        ])
         when 'video/x-msvideo'
           VideoDerivatives.create(self, source: :original_file,
                                         outputs: [
                                           { label: :mp4,       format: 'mp4',  url: "#{uri}/original_file_mp4" },
                                           { label: :webm,      format: 'webm', url: "#{uri}/original_file_webm" },
-                                          { label: :thumbnail, format: 'jpg',  url: "#{uri}/thumbnail" }])
+                                          { label: :thumbnail, format: 'jpg',  url: "#{uri}/thumbnail" }
+                                        ])
         when 'image/png', 'image/jpg'
           ImageDerivatives.create(self, source: :original_file,
-                                  outputs: [
-                                    { label: :medium, size: "300x300>", url: "#{uri}/original_file_medium" },
-                                    { label: :thumb,  size: "100x100>", url: "#{uri}/original_file_thumb" },
-                                    { label: :access, format: 'jpg',    url: "#{uri}/access" },
-          ])
+                                        outputs: [
+                                          { label: :medium, size: "300x300>", url: "#{uri}/original_file_medium" },
+                                          { label: :thumb,  size: "100x100>", url: "#{uri}/original_file_thumb" },
+                                          { label: :access, format: 'jpg',    url: "#{uri}/access" }
+                                        ])
         when 'application/vnd.ms-powerpoint'
           DocumentDerivatives.create(self, source: :original_file,
                                            outputs: [
                                              { label: :preservation, format: 'pptx', url: "#{uri}/original_file_preservation" },
                                              { label: :access,       format: 'pdf',  url: "#{uri}/original_file_access" },
-                                             { label: :thumnail,     format: 'jpg',  url: "#{uri}/original_file_thumbnail" }])
+                                             { label: :thumnail,     format: 'jpg',  url: "#{uri}/original_file_thumbnail" }
+                                           ])
         when 'text/rtf'
           DocumentDerivatives.create(self, source: :original_file,
                                            outputs: [
                                              { label: :preservation, format: 'odt', url: "#{uri}/original_file_preservation" },
                                              { label: :access,       format: 'pdf', url: "#{uri}/original_file_access" },
-                                             { label: :thumnail,     format: 'jpg', url: "#{uri}/original_file_thumbnail" }])
+                                             { label: :thumnail,     format: 'jpg', url: "#{uri}/original_file_thumbnail" }
+                                           ])
         when 'application/msword'
           DocumentDerivatives.create(self, source: :original_file,
                                            outputs: [
                                              { label: :preservation, format: 'docx', url: "#{uri}/original_file_preservation" },
                                              { label: :access,       format: 'pdf',  url: "#{uri}/original_file_access" },
-                                             { label: :thumnail,     format: 'jpg',  url: "#{uri}/original_file_thumbnail" }])
+                                             { label: :thumnail,     format: 'jpg',  url: "#{uri}/original_file_thumbnail" }
+                                           ])
         when 'application/vnd.ms-excel'
           DocumentDerivatives.create(self, source: :original_file,
                                            outputs: [
                                              { label: :preservation, format: 'xlsx', url: "#{uri}/original_file_preservation" },
                                              { label: :access,       format: 'pdf',  url: "#{uri}/original_file_access" },
-                                             { label: :thumnail,     format: 'jpg',  url: "#{uri}/original_file_thumbnail" }])
+                                             { label: :thumnail,     format: 'jpg',  url: "#{uri}/original_file_thumbnail" }
+                                           ])
         when 'image/tiff'
           Jpeg2kImageDerivatives.create(self, source: :original_file,
                                               outputs: [
                                                 { label: :resized,       format: 'jp2', recipe: :default, processor: 'jpeg2k_image', resize: "600x600>", url: "#{uri}/resized" },
                                                 { label: :config_lookup, format: 'jp2', recipe: :default, processor: 'jpeg2k_image', url: "#{uri}/config_lookup" },
                                                 { label: :string_recipe, format: 'jp2', recipe: '-jp2_space sRGB', processor: 'jpeg2k_image', url: "#{uri}/string_recipe" },
-                                                { label: :diy,           format: 'jp2', processor: 'jpeg2k_image', url: "#{uri}/original_file_diy" }])
+                                                { label: :diy,           format: 'jp2', processor: 'jpeg2k_image', url: "#{uri}/original_file_diy" }
+                                              ])
         when 'image/x-adobe-dng'
           ImageDerivatives.create(self, source: :original_file,
                                         outputs: [
                                           { label: :access, size: "300x300>", format: 'jpg', processor: :raw_image, url: "#{uri}/original_file_access" },
-                                          { label: :thumb,  size: "100x100>", format: 'jpg', processor: :raw_image, url: "#{uri}/original_file_thumb" }])
+                                          { label: :thumb,  size: "100x100>", format: 'jpg', processor: :raw_image, url: "#{uri}/original_file_thumb" }
+                                        ])
         end
       end
     end
@@ -210,7 +218,7 @@ describe "Transcoding" do
       expect(file.attached_files['thumbnail'].mime_type).to eq('image/jpeg')
     end
 
-    context "and the timeout is set" do
+    context "when the timeout is set" do
       before do
         Hydra::Derivatives::Processors::Video::Processor.timeout = 0.2 # 200ms
       end


### PR DESCRIPTION
Note: This is a work in progress as I work through a few of the more complex exclusions here (which may stay as exclusions, there were initially 500+ violations).

This updates rubocop to 0.52.0 to address the reported vulnerability concern.
