### PR TITLE
Amending documentation on configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Hydra::Derivatives::Processors::ActiveEncode.timeout = 5.minutes
 
 ```
 
+You can add this to a `config/initializers/` file ([see Scholarsphere as an example](https://github.com/psu-stewardship/scholarsphere/blob/e16586c4bf6f7aed652924acc47dbe4ec774ff00/config/initializers/hydra_derivatives_config.rb#L5)). Another possibility, though unverified, is that you may try adding it to your `config/application.rb` or even vary by environments (e.g. `config/environments/test.rb`).
+
 ### Video Processing configuration
 
 Flags can be set for using different video codes.  Default codecs are shown below


### PR DESCRIPTION
Based on conversations on Slack:

Person 1:

> I get from Readme of Hydra-derivatives but is not clear for my where
> can I put in my project

Person 2:
> I would guess and say in a config file, such as
> `/config/application.rb`, or narrow it down to `/config/environments`
> dev/test/prod etc. (edited)
>
> I suppose, another option is putting it inside an initializer just for hydra-derivatives.

Person 3
> I found a scholarsphere implementation https://github.com/psu-stewardship/scholarsphere/blob/master/config/initializers/hydra_derivatives_config.rb#L5
> However…I think Person 2's suggestion would also work (and allow for
> less antics if you want variation between environments).