### PR TITLE
restore original_name= to removed instead of deprecated

### DIFF
--- a/lib/hydra/derivatives/io_decorator.rb
+++ b/lib/hydra/derivatives/io_decorator.rb
@@ -15,6 +15,8 @@ module Hydra
       attr_accessor :mime_type, :original_filename
       alias original_name original_filename
       deprecation_deprecate original_name: 'original_name has been deprecated. Use original_filename instead. This will be removed in hydra-derivatives 4.0'
+      alias original_name= original_filename=
+      deprecation_deprecate :"original_name=" => 'original_name= has been deprecated. Use original_filename= instead. This will be removed in hydra-derivatives 4.0'
 
       def initialize(file, mime_type = nil, original_filename = nil)
         super(file)


### PR DESCRIPTION
Removing this broke backwards compat in 3.x series, and broke sufia 7/curation concerns 1.7 trying to new h-d 3.4. 

Restore the writer as deprecated, same as the #original_name reader is. Recommend 3.4.1 release with this.

Closes #181

Ref https://github.com/samvera/sufia/pull/3183