### PR TITLE
Force document thumbnails to be png

### DIFF
--- a/lib/hydra/derivatives/processors/document.rb
+++ b/lib/hydra/derivatives/processors/document.rb
@@ -27,9 +27,11 @@ module Hydra::Derivatives::Processors
         end
       end
 
+      # @note Forces png files instead of jpegs for thumbnails. Processing jpgs seems to take much more time than pngs.
+      # @todo It would be good if we could configure this instead of overriding
       def converted_file
         @converted_file ||= if directives.fetch(:format) == "jpg"
-                              convert_to("pdf")
+                              convert_to("png")
                             else
                               convert_to(directives.fetch(:format))
                             end

--- a/spec/processors/document_spec.rb
+++ b/spec/processors/document_spec.rb
@@ -6,11 +6,15 @@ describe Hydra::Derivatives::Processors::Document do
   let(:source_path)    { File.join(fixture_path, "test.doc") }
   let(:output_service) { Hydra::Derivatives::PersistBasicContainedOutputFileService }
 
-  before { allow(subject).to receive(:converted_file).and_return(converted_file) }
+  before do
+    allow(subject).to receive(:output_file_service).and_return(output_service)
+    allow(subject).to receive(:convert_to).with(convert_directive).and_return(converted_file)
+  end
 
   describe "#encode_file" do
     context "when converting to jpg" do
-      let(:directives)     { { format: "jpg" } }
+      let(:directives) { { format: "jpg" } }
+      let(:convert_directive) { "png" }
       let(:converted_file) { "path/to/pdf/created/from/original" }
       let(:mock_processor) { double }
 
@@ -26,11 +30,13 @@ describe Hydra::Derivatives::Processors::Document do
     end
 
     context "when converting to another format" do
-      let(:directives)     { { format: "png" } }
+      let(:directives) { { format: "png" } }
+      let(:convert_directive) { "png" }
       let(:converted_file) { "path/to/converted.png" }
       let(:mock_content)   { "mocked png content" }
 
       before { allow(File).to receive(:read).with(converted_file).and_return(mock_content) }
+
       it "creates a thumbnail of the document" do
         expect(output_service).to receive(:call).with(mock_content, directives)
         expect(File).to receive(:unlink).with(converted_file)


### PR DESCRIPTION
When creating thumbnails for office documents, the default jpeg format
takes a considerable amount of processing time due to the intervening
pdf that is created from the document in order to generate the jpeg
thumbnail. Creating a png for the thumbnail instead is much faster.