### PR TITLE
fixed bug where non-jpg document derivatives fail

### DIFF
--- a/lib/hydra/derivatives/processors/document.rb
+++ b/lib/hydra/derivatives/processors/document.rb
@@ -23,7 +23,7 @@ module Hydra::Derivatives::Processors
         if directives.fetch(:format) == "jpg"
           Hydra::Derivatives::Processors::Image.new(converted_file, directives).process
         else
-          output_file_service.call(File.read(converted_file), directives)
+          output_file_service.call(File.open(converted_file, 'rb'), directives)
         end
       end
 


### PR DESCRIPTION
Before, in the documents processor, files would open from /tmp as a string, and then fail during IO.copy_stream in Hyrax here: https://github.com/samvera/hyrax/blob/master/app/services/hyrax/persist_derivatives.rb#L13

Now, it opens them as binary and works as intended.