### PR TITLE
Update list of Ruby versions for travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ before_install:
   - gem update --system
   - gem install bundler
 rvm:
-  - 2.2.5
-  - 2.3.4
-  - 2.4.1
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/hydra-derivatives.gemspec
+++ b/hydra-derivatives.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'fcrepo_wrapper', '~> 0.2'
   spec.add_development_dependency 'rake', '~> 10.1'
   spec.add_development_dependency 'rspec', '~> 3.1'


### PR DESCRIPTION
This fixes test failures due to an old version of Ruby not being able to pull gems.  This also updates to newer Ruby versions so tests are running against the latest 2.x.x.