### PR TITLE
Pass global id of encode to output service

### DIFF
--- a/hydra-derivatives.gemspec
+++ b/hydra-derivatives.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "solr_wrapper", "~> 0.4"
 
   spec.add_dependency 'active-fedora', '>= 11.3.1', '< 13'
-  spec.add_dependency 'active_encode', '~>0.1'
+  spec.add_dependency 'active_encode', '~>0.4'
   spec.add_dependency 'activesupport', '>= 4.0', '< 6'
   spec.add_dependency 'addressable', '~>2.5'
   spec.add_dependency 'deprecation'

--- a/lib/hydra/derivatives/processors/active_encode.rb
+++ b/lib/hydra/derivatives/processors/active_encode.rb
@@ -22,6 +22,8 @@ module Hydra::Derivatives::Processors
     def process
       @encode_job = encode_class.create(source_path, directives)
       timeout ? wait_for_encode_job_with_timeout : wait_for_encode_job
+      # Pass encode global id to output file service
+      directives[:encode_global_id] = encode_job.to_global_id.to_s
       encode_job.output.each do |output|
         output_file_service.call(output, directives)
       end


### PR DESCRIPTION
ActiveEncode version 0.2+ implements GlobalID.  This PR passes the global id of the encode job along to the output file service so it can be stored and used for fetching further information from ActiveEncode like status information or technical metadata.