### PR TITLE
Fix shell execution

### DIFF
--- a/spec/processors/shell_based_processor_spec.rb
+++ b/spec/processors/shell_based_processor_spec.rb
@@ -10,10 +10,19 @@ describe Hydra::Derivatives::Processors::ShellBasedProcessor do
   after { Object.send(:remove_const, :TestProcessor) }
 
   let(:processor) { TestProcessor.new }
+  let(:proc_class) { TestProcessor }
 
   describe "options_for" do
     it "returns a hash" do
       expect(processor.options_for("a")).to be_a Hash
+    end
+  end
+
+  describe ".execute" do
+    context "when an EOF error occurs" do
+      it "doesn't crash" do
+        proc_class.execute("echo foo")
+      end
     end
   end
 end


### PR DESCRIPTION
Closes stderr and stdout at the end of the process, rather than never
closing stderr, and closing stdout before there's time for any data to
come in.  This fixes a crash when processes (like opj_compress) print
out to stdout a lot.

Fixes an edge case where an EOFError causes an invocation of a
non-existent "Rails.logger" function.  In Rails, it would be
Rails.logger.debug or something, and outside Rails contexts, there is no
Rails.logger at all.  This was never noticed before, as EOFs weren't
detected because the previous logic never checked stdout, since it was
already closed.