### PR TITLE
Fix typo in default mime_type value

### DIFF
--- a/lib/hydra/derivatives/services/persist_output_file_service.rb
+++ b/lib/hydra/derivatives/services/persist_output_file_service.rb
@@ -23,7 +23,7 @@ module Hydra::Derivatives
       if file.respond_to? :mime_type
         file.mime_type
       else
-        "appliction/octet-stream"
+        "application/octet-stream"
       end
     end
   end


### PR DESCRIPTION
Stumbled across this typo while using this class; there's no open issue for it, but I can add one if that's the preferred workflow.