### PR TITLE
Solr extract service now succeeds over SSL

### DIFF
--- a/lib/hydra/derivatives/processors/document.rb
+++ b/lib/hydra/derivatives/processors/document.rb
@@ -23,7 +23,7 @@ module Hydra::Derivatives::Processors
         if directives.fetch(:format) == "jpg"
           Hydra::Derivatives::Processors::Image.new(converted_file, directives).process
         else
-          output_file_service.call(File.open(converted_file, 'rb'), directives)
+          output_file_service.call(File.read(converted_file), directives)
         end
       end
 

--- a/lib/hydra/derivatives/processors/document.rb
+++ b/lib/hydra/derivatives/processors/document.rb
@@ -23,7 +23,7 @@ module Hydra::Derivatives::Processors
         if directives.fetch(:format) == "jpg"
           Hydra::Derivatives::Processors::Image.new(converted_file, directives).process
         else
-          output_file_service.call(File.read(converted_file), directives)
+          output_file_service.call(File.open(converted_file, 'rb'), directives)
         end
       end
 

--- a/lib/hydra/derivatives/processors/full_text.rb
+++ b/lib/hydra/derivatives/processors/full_text.rb
@@ -33,8 +33,8 @@ module Hydra::Derivatives::Processors
       # @return [Net::HttpResponse] the result of calling the extract service
       def http_request
         Net::HTTP.start(uri.host, uri.port) do |http|
+          http.use_ssl = true if check_for_ssl
           req = Net::HTTP::Post.new(uri.request_uri, request_headers)
-          req.use_ssl = true if check_for_ssl
           req.basic_auth uri.user, uri.password unless uri.password.nil?
           req.body = file_content
           http.request req

--- a/lib/hydra/derivatives/processors/full_text.rb
+++ b/lib/hydra/derivatives/processors/full_text.rb
@@ -33,8 +33,8 @@ module Hydra::Derivatives::Processors
       # @return [Net::HttpResponse] the result of calling the extract service
       def http_request
         Net::HTTP.start(uri.host, uri.port) do |http|
-          http.use_ssl = true if check_for_ssl
           req = Net::HTTP::Post.new(uri.request_uri, request_headers)
+          req.use_ssl = true if check_for_ssl
           req.basic_auth uri.user, uri.password unless uri.password.nil?
           req.body = file_content
           http.request req

--- a/lib/hydra/derivatives/processors/full_text.rb
+++ b/lib/hydra/derivatives/processors/full_text.rb
@@ -32,9 +32,8 @@ module Hydra::Derivatives::Processors
       # Send the request to the extract service
       # @return [Net::HttpResponse] the result of calling the extract service
       def http_request
-        Net::HTTP.start(uri.host, uri.port) do |http|
+        Net::HTTP.start(uri.host, uri.port, :use_ssl => check_for_ssl) do |http|
           req = Net::HTTP::Post.new(uri.request_uri, request_headers)
-          req.use_ssl = true if check_for_ssl
           req.basic_auth uri.user, uri.password unless uri.password.nil?
           req.body = file_content
           http.request req


### PR DESCRIPTION
The Solr extract service started failing with `undefined method 'use_ssl=' for #<Net::HTTP::Post POST>` after updating hyrax from 2.5.1 to 2.6.0. This was using ruby 2.4.1 with rails 5.1.6.2. It looks like this commit was the culprit: [https://github.com/samvera/hydra-derivatives/commit/35a6e7165cec5ea9ccc43163454af6cbc4fd6053](https://github.com/samvera/hydra-derivatives/commit/35a6e7165cec5ea9ccc43163454af6cbc4fd6053). I pasted the full sidekiq error below.

It seems like the .use_ssl method should apply to `Net::HTTP.start`, not `Net::HTTP::Post` here: https://github.com/samvera/hydra-derivatives/blob/master/lib/hydra/derivatives/processors/full_text.rb#L37

Net::HTTP.start Docs: [https://ruby-doc.org/stdlib-2.6.5/libdoc/net/http/rdoc/Net/HTTP.html#method-i-use_ssl-3D](https://ruby-doc.org/stdlib-2.6.5/libdoc/net/http/rdoc/Net/HTTP.html#method-i-use_ssl-3D).

It also has to be called _before_ `Net::HTTP.start`, instead of after. I think this fixes it, but I'm not sure if you want to patch it another way, as the multiple commits was from my inability to use git revert correctly. 

FYI, this repo also contains https://github.com/samvera/hydra-derivatives/pull/185, so that maybe should be looked at as well, but I think there was some uncertainly over fixing it on the Hyrax-side or hydra-derivatives side.

"""
2019-11-01T16:12:56.135Z 5342 TID-1e9wk6 CreateDerivativesJob JID-5649220ad1e560a1644e1f2c INFO: start
2019-11-01T16:13:00.001Z 5342 TID-1e9wk6 CreateDerivativesJob JID-5649220ad1e560a1644e1f2c INFO: fail: 3.866 sec
2019-11-01T16:13:00.002Z 5342 TID-1e9wk6 WARN: {"context":"Job raised exception","job":{"class":"ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper","wrapped":"CreateDerivativesJob","queue":"default","args":[{"job_class":"CreateDerivativesJob","job_id":"3fc5eb95-1944-4a1b-8b5f-1a9bdd2b8fbc","provider_job_id":null,"queue_name":"default","priority":null,"arguments":[{"_aj_globalid":"gid://hyrax/FileSet/gb19fq470"},"gb19fq470/files/d4191965-0fa9-4960-ac4d-f5995bdc30e1","/media/Library/ESPYderivatives/files/ua435/01 Brochure/beer game insert 01.doc"],"executions":0,"locale":"en"}],"retry":true,"jid":"5649220ad1e560a1644e1f2c","created_at":1572622086.4895666,"enqueued_at":1572624776.1350782,"error_message":"undefined method `use_ssl=' for #<Net::HTTP::Post POST>","error_class":"NoMethodError","failed_at":1572622090.4100199,"retry_count":6,"retried_at":1572623437.676636},"jobstr":"{\"class\":\"ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper\",\"wrapped\":\"CreateDerivativesJob\",\"queue\":\"default\",\"args\":[{\"job_class\":\"CreateDerivativesJob\",\"job_id\":\"3fc5eb95-1944-4a1b-8b5f-1a9bdd2b8fbc\",\"provider_job_id\":null,\"queue_name\":\"default\",\"priority\":null,\"arguments\":[{\"_aj_globalid\":\"gid://hyrax/FileSet/gb19fq470\"},\"gb19fq470/files/d4191965-0fa9-4960-ac4d-f5995bdc30e1\",\"/media/Library/ESPYderivatives/files/ua435/01 Brochure/beer game insert 01.doc\"],\"executions\":0,\"locale\":\"en\"}],\"retry\":true,\"jid\":\"5649220ad1e560a1644e1f2c\",\"created_at\":1572622086.4895666,\"enqueued_at\":1572624776.1350782,\"error_message\":\"undefined method `use_ssl=' for #<Net::HTTP::Post POST>\",\"error_class\":\"NoMethodError\",\"failed_at\":1572622090.4100199,\"retry_count\":6,\"retried_at\":1572623437.676636}"}
2019-11-01T16:13:00.002Z 5342 TID-1e9wk6 WARN: NoMethodError: undefined method `use_ssl=' for #<Net::HTTP::Post POST>
2019-11-01T16:13:00.002Z 5342 TID-1e9wk6 WARN: /usr/local/rvm/gems/ruby-2.4.1@hyrax/bundler/gems/hydra-derivatives-1c87e962d5bc/lib/hydra/derivatives/processors/full_text.rb:37:in `block in http_request'
/usr/local/rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/net/http.rb:877:in `start'
/usr/local/rvm/rubies/ruby-2.4.1/lib/ruby/2.4.0/net/http.rb:608:in `start'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/bundler/gems/hydra-derivatives-1c87e962d5bc/lib/hydra/derivatives/processors/full_text.rb:35:in `http_request'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/bundler/gems/hydra-derivatives-1c87e962d5bc/lib/hydra/derivatives/processors/full_text.rb:25:in `fetch'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/bundler/gems/hydra-derivatives-1c87e962d5bc/lib/hydra/derivatives/processors/full_text.rb:18:in `extract'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/bundler/gems/hydra-derivatives-1c87e962d5bc/lib/hydra/derivatives/processors/full_text.rb:7:in `process'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/bundler/gems/hydra-derivatives-1c87e962d5bc/lib/hydra/derivatives/runners/runner.rb:30:in `block (2 levels) in create'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/bundler/gems/hydra-derivatives-1c87e962d5bc/lib/hydra/derivatives/runners/runner.rb:27:in `each'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/bundler/gems/hydra-derivatives-1c87e962d5bc/lib/hydra/derivatives/runners/runner.rb:27:in `block in create'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/hyrax-2.6.0/app/services/hyrax/local_file_service.rb:7:in `call'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/bundler/gems/hydra-derivatives-1c87e962d5bc/lib/hydra/derivatives/runners/runner.rb:41:in `source_file'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/bundler/gems/hydra-derivatives-1c87e962d5bc/lib/hydra/derivatives/runners/runner.rb:26:in `create'
/var/www/hyrax-UAlbany/app/services/hyrax/file_set_derivatives_service.rb:111:in `extract_full_text'
/var/www/hyrax-UAlbany/app/services/hyrax/file_set_derivatives_service.rb:74:in `create_office_document_derivatives'
/var/www/hyrax-UAlbany/app/services/hyrax/file_set_derivatives_service.rb:25:in `create_derivatives'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/hyrax-2.6.0/app/models/concerns/hyrax/file_set/derivatives.rb:51:in `create_derivatives'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/hyrax-2.6.0/app/jobs/create_derivatives_job.rb:11:in `perform'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activejob-5.1.6.2/lib/active_job/execution.rb:37:in `block in perform_now'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/callbacks.rb:108:in `block in run_callbacks'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/i18n-1.7.0/lib/i18n.rb:297:in `with_locale'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activejob-5.1.6.2/lib/active_job/translation.rb:7:in `block (2 levels) in <module:Translation>'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/callbacks.rb:117:in `instance_exec'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/callbacks.rb:117:in `block in run_callbacks'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activejob-5.1.6.2/lib/active_job/logging.rb:24:in `block (4 levels) in <module:Logging>'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/notifications.rb:166:in `block in instrument'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/notifications.rb:166:in `instrument'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activejob-5.1.6.2/lib/active_job/logging.rb:23:in `block (3 levels) in <module:Logging>'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activejob-5.1.6.2/lib/active_job/logging.rb:44:in `block in tag_logger'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/tagged_logging.rb:69:in `block in tagged'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/tagged_logging.rb:26:in `tagged'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/tagged_logging.rb:69:in `tagged'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activejob-5.1.6.2/lib/active_job/logging.rb:44:in `tag_logger'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activejob-5.1.6.2/lib/active_job/logging.rb:20:in `block (2 levels) in <module:Logging>'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/callbacks.rb:117:in `instance_exec'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/callbacks.rb:117:in `block in run_callbacks'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/callbacks.rb:135:in `run_callbacks'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activejob-5.1.6.2/lib/active_job/execution.rb:33:in `perform_now'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activejob-5.1.6.2/lib/active_job/execution.rb:22:in `block in execute'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/callbacks.rb:108:in `block in run_callbacks'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activejob-5.1.6.2/lib/active_job/railtie.rb:26:in `block (4 levels) in <class:Railtie>'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/execution_wrapper.rb:85:in `wrap'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/reloader.rb:68:in `block in wrap'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/execution_wrapper.rb:81:in `wrap'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/reloader.rb:67:in `wrap'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activejob-5.1.6.2/lib/active_job/railtie.rb:25:in `block (3 levels) in <class:Railtie>'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/callbacks.rb:117:in `instance_exec'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/callbacks.rb:117:in `block in run_callbacks'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/callbacks.rb:135:in `run_callbacks'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activejob-5.1.6.2/lib/active_job/execution.rb:20:in `execute'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activejob-5.1.6.2/lib/active_job/queue_adapters/sidekiq_adapter.rb:40:in `perform'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/processor.rb:187:in `execute_job'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/processor.rb:169:in `block (2 levels) in process'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/middleware/chain.rb:128:in `block in invoke'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/middleware/chain.rb:133:in `invoke'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/processor.rb:168:in `block in process'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/processor.rb:139:in `block (6 levels) in dispatch'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/job_retry.rb:98:in `local'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/processor.rb:138:in `block (5 levels) in dispatch'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/rails.rb:42:in `block in call'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/execution_wrapper.rb:85:in `wrap'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/reloader.rb:68:in `block in wrap'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/execution_wrapper.rb:85:in `wrap'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/activesupport-5.1.6.2/lib/active_support/reloader.rb:67:in `wrap'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/rails.rb:41:in `call'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/processor.rb:134:in `block (4 levels) in dispatch'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/processor.rb:199:in `stats'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/processor.rb:129:in `block (3 levels) in dispatch'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/job_logger.rb:8:in `call'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/processor.rb:128:in `block (2 levels) in dispatch'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/job_retry.rb:73:in `global'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/processor.rb:127:in `block in dispatch'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/logging.rb:48:in `with_context'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/logging.rb:42:in `with_job_hash_context'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/processor.rb:126:in `dispatch'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/processor.rb:167:in `process'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/processor.rb:85:in `process_one'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/processor.rb:73:in `run'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/util.rb:16:in `watchdog'
/usr/local/rvm/gems/ruby-2.4.1@hyrax/gems/sidekiq-5.1.3/lib/sidekiq/util.rb:25:in `block in safe_thread'
"""