### PR TITLE
Removing spec files from gem distribution

### DIFF
--- a/hydra-derivatives.gemspec
+++ b/hydra-derivatives.gemspec
@@ -10,9 +10,8 @@ Gem::Specification.new do |spec|
   spec.license       = "APACHE2"
   spec.homepage      = "https://github.com/projecthydra/hydra-derivatives"
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR).select { |f| File.dirname(f) !~ %r{\A"?spec|test|features\/?} }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/hydra-derivatives.gemspec
+++ b/hydra-derivatives.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'fcrepo_wrapper', '~> 0.2'
+  spec.add_development_dependency 'rails', '> 5.1', '< 7.0'
   spec.add_development_dependency 'rake', '~> 10.1'
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency "solr_wrapper", "~> 2.0"


### PR DESCRIPTION
Removing the test_files from the gemspec ensures that consumers of the Gem are not required to download any fixture files with the Gem (please see samvera/hyrax#4245 for the origin discussion).