### PR TITLE
Ensure a nonnegative calculated Clevels value

### DIFF
--- a/lib/hydra/derivatives/processors/jpeg2k_image.rb
+++ b/lib/hydra/derivatives/processors/jpeg2k_image.rb
@@ -51,6 +51,7 @@ module Hydra::Derivatives::Processors
       end
 
       def level_count_for_size(long_dim)
+        return 0 if long_dim < 96
         levels = 0
         level_size = long_dim
         while level_size >= 96

--- a/spec/processors/jpeg2k_spec.rb
+++ b/spec/processors/jpeg2k_spec.rb
@@ -8,9 +8,14 @@ describe Hydra::Derivatives::Processors::Jpeg2kImage do
   let(:image) { MiniMagick::Image.open(filename) }
 
   describe "#calculate_recipe" do
-    it "calculates the number of levels from a size" do
+    it "calculates the number of levels from a size above the minimum threshold" do
       dim = 7200
       expect(described_class.level_count_for_size(dim)).to eq(6)
+    end
+
+    it "calculates the number of levels as 0 from a size below the minimum threshold" do
+      dim = 50
+      expect(described_class.level_count_for_size(dim)).to eq(0)
     end
 
     it "calculates the compression rates for each quality layer" do


### PR DESCRIPTION
kdu_compress crashes with a negative Clevels value, but succeeds with a zero.

Resolves #217 

@jenlindner I _think_ this captures the approach you recommended?