### PR TITLE
Standardize 'gray' (rather than 'grey') across all instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Instead, each directive may contain these arguments:
   * `:to_srgb` (Boolean) : If `true` and the image is a color image it will map the source image color profile to sRGB. Default: `true`
   * `:resize` (String) : Geometry; the same syntax as the `Hydra::Derivatives::Image` processor
   * `:recipe` :
-    - If a Symbol the recipe will be read from the `Hydra::Derivatives.kdu_compress_recipes` hash. You can override this, or a couple of samples are supplied. The symbol in the config file should be the name in the model + `_{quality}`, e.g. `recipe: :default` will look `:default_color` or `:default_grey` in the hash.
+    - If a Symbol the recipe will be read from the `Hydra::Derivatives.kdu_compress_recipes` hash. You can override this, or a couple of samples are supplied. The symbol in the config file should be the name in the model + `_{quality}`, e.g. `recipe: :default` will look `:default_color` or `:default_gray` in the hash.
     - If a String the recipe in the string will be used. You may include anything the command line utility will accept except `-i` or `-o`. See `$ kdu_compress -usage` in your shell.
     - If no `:recipe` is provided the processor will examine the image and make a best guess, but you can set a few basic options (the remainder of this list). Note that these are ignored if you provided a recipe via either of the first two methods described.
   * `:levels` (Integer) : The number of decomposition levels. The default is the number of times the long dimension can be divided by two, down to 96, e.g. a 7200 pixel image would have 6 levels (3600, 1800, 900, 450, 225, 112)

--- a/lib/hydra/derivatives/config.rb
+++ b/lib/hydra/derivatives/config.rb
@@ -57,7 +57,7 @@ module Hydra
             ORGgen_plt=yes
             ORGtparts=R
             "Stiles={1024,1024}" ).gsub(/\s+/, " ").strip,
-          default_grey: %(-rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171
+          default_gray: %(-rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171
             -jp2_space sLUM
             -double_buffering 10
             -num_threads 4

--- a/solr/config/xslt/example.xsl
+++ b/solr/config/xslt/example.xsl
@@ -124,7 +124,7 @@
       td { vertical-align: top; }
       ul { margin: 0px; margin-left: 1em; padding: 0px; }
       .note { font-size:80%; }
-      .doc { margin-top: 1em; border-top: solid grey 1px; }
+      .doc { margin-top: 1em; border-top: solid gray 1px; }
       .exp { display: none; font-family: monospace; white-space: pre; }
     </style>
   </xsl:template>

--- a/solr/config/xslt/luke.xsl
+++ b/solr/config/xslt/luke.xsl
@@ -326,7 +326,7 @@
         <style type="text/css">
             <![CDATA[
             td.name {font-style: italic; font-size:80%; }
-            .doc { margin: 0.5em; border: solid grey 1px; }
+            .doc { margin: 0.5em; border: solid gray 1px; }
             .exp { display: none; font-family: monospace; white-space: pre; }
             div.histogram { background: none repeat scroll 0%; -moz-background-clip: -moz-initial; -moz-background-origin: -moz-initial; -moz-background-inline-policy: -moz-initial;}
             table.histogram { width: auto; vertical-align: bottom; }

--- a/spec/fixtures/jpeg2k_config.yml
+++ b/spec/fixtures/jpeg2k_config.yml
@@ -5,7 +5,7 @@ defaults: &defaults
       -rate 2.4
       -jp2_space sRGB
       Stiles=\{1024,1024\}
-    :myrecipe_grey: >
+    :myrecipe_gray: >
       -rate 2.4
       -jp2_space sLUM
       Stiles=\{1024,1024\}

--- a/spec/processors/jpeg2k_spec.rb
+++ b/spec/processors/jpeg2k_spec.rb
@@ -37,26 +37,26 @@ describe Hydra::Derivatives::Processors::Jpeg2kImage do
 
     it "can get the recipe from a config file" do
       args = { recipe: :myrecipe }
-      r = described_class.kdu_compress_recipe(args, 'grey', 7200)
-      expect(r).to eq(@sample_cfg['jp2_recipes'][:myrecipe_grey])
+      r = described_class.kdu_compress_recipe(args, 'gray', 7200)
+      expect(r).to eq(@sample_cfg['jp2_recipes'][:myrecipe_gray])
     end
 
     it "can take a recipe as a string" do
       args = { recipe: '-my -excellent -recipe' }
-      r = described_class.kdu_compress_recipe(args, 'grey', 7200)
+      r = described_class.kdu_compress_recipe(args, 'gray', 7200)
       expect(r).to eq(args[:recipe])
     end
 
     it "will fall back to a #calculate_recipe if a symbol is passed but no recipe is found" do
       args = { recipe: :x }
-      r = described_class.kdu_compress_recipe(args, 'grey', 7200)
-      expect(r).to eq(described_class.calculate_recipe(args, 'grey', 7200))
+      r = described_class.kdu_compress_recipe(args, 'gray', 7200)
+      expect(r).to eq(described_class.calculate_recipe(args, 'gray', 7200))
     end
 
     it "will fall back to a #calculate_recipe if there is no attempt to provide one" do
       args = {}
-      r = described_class.kdu_compress_recipe(args, 'grey', 7200)
-      expect(r).to eq(described_class.calculate_recipe(args, 'grey', 7200))
+      r = described_class.kdu_compress_recipe(args, 'gray', 7200)
+      expect(r).to eq(described_class.calculate_recipe(args, 'gray', 7200))
     end
   end
 


### PR DESCRIPTION
The CSS changes aren't strictly necessary, but the other changes should resolve the recipe lookup issue (#218).