### PR TITLE
Rails6 update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,9 @@ jobs:
             fi
             sudo cp kakadu/*.so /usr/lib
             sudo cp kakadu/* /usr/bin
+      - run:
+          name: Modify ImageMagick security policy
+          command: sudo sed -i 's/policy domain="coder" rights="none" pattern="PDF"/policy domain="coder" rights="read|write" pattern="PDF"/' /etc/ImageMagick-6/policy.xml
 
       - samvera/bundle_for_gem:
           ruby_version: << parameters.ruby_version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
         type: string
       bundler_version:
         type: string
-        default: 2.0.1
+        default: 2.1.4
     executor:
       name: 'samvera/ruby_fcrepo_solr'
       ruby_version: << parameters.ruby_version >>
@@ -49,18 +49,18 @@ workflows:
   ci:
     jobs:
       - bundle_lint_test:
-          name: ruby2-4-6
-          ruby_version: 2.4.6
+          name: ruby2-4
+          ruby_version: 2.4.10
           project: hydra-derivatives
       - bundle_lint_test:
-          name: ruby2-5-5
-          ruby_version: 2.5.5
+          name: ruby2-5
+          ruby_version: 2.5.8
           project: hydra-derivatives
       - bundle_lint_test:
-          name: ruby2-6-3
-          ruby_version: 2.6.3
+          name: ruby2-6
+          ruby_version: 2.6.6
           project: hydra-derivatives
       - bundle_lint_test:
-          name: ruby2-7-0
-          ruby_version: 2.7.0
+          name: ruby2-7
+          ruby_version: 2.7.1
           project: hydra-derivatives

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
     - Rakefile
 
 Layout/IndentationConsistency:
-  EnforcedStyle: indented_internal_methods
+  EnforcedStyle: rails
 
 Metrics/AbcSize:
   Max: 42

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 # Please see hydra-derivatives.gemspec for dependency information.
 gemspec
 
-gem 'active-fedora', git: 'https://github.com/samvera/active_fedora.git'
 gem 'sprockets', '~> 3.7'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Please see hydra-derivatives.gemspec for dependency information.
 gemspec
 
-gem 'active-fedora', git: 'https://github.com/jrgriffiniii/active_fedora.git', branch: 'rails6-update'
+gem 'active-fedora', git: 'https://github.com/samvera/active_fedora.git'
 gem 'sprockets', '~> 3.7'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,13 @@ source 'https://rubygems.org'
 # Please see hydra-derivatives.gemspec for dependency information.
 gemspec
 
+gem 'active-fedora', git: 'https://github.com/jrgriffiniii/active_fedora.git', branch: 'rails6-update'
+gem 'sprockets', '~> 3.7'
+
 group :development, :test do
-  gem 'byebug' unless ENV['TRAVIS']
   gem 'coveralls'
+  gem 'rspec_junit_formatter'
   gem 'rubocop', '~> 0.52.0', require: false
   gem 'rubocop-rspec', require: false
   gem 'simplecov'
-  gem 'rspec_junit_formatter'
 end

--- a/README.md
+++ b/README.md
@@ -195,6 +195,11 @@ MAGICK_TEMPDIR
 ```
 YMMV as to where setting them will take effect in your app; the application's web server's vhost directives are a location known to work with an Apache web server set up.
 
+ImageMagick by default disables reading and writing of PDFs due to a [vulnerability in ghostscript](https://www.kb.cert.org/vuls/id/332928/). Make sure to install a fixed version of ghostscript and modify ImageMagick's security policy to allow reading and writing PDFs:
+```
+sudo sed -i 's/policy domain="coder" rights="none" pattern="PDF"/policy domain="coder" rights="read|write" pattern="PDF"/' /etc/ImageMagick-6/policy.xml
+```
+
 ## JPEG2k Directives
 
 Unlike the other processors, the `Jpeg2kImage` processor does not generally accept arguments that directly (or nearly so) translate to the arguments you would give to the corresponding command line utility.

--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ namespace :derivatives do
   end
 
   RSpec::Core::RakeTask.new(:rspec) do |task|
-    task.rspec_opts = "--tag ~requires_kdu_compress" if ENV['TRAVIS']
+    task.rspec_opts = "--tag ~requires_kdu_compress" if ENV['CI']
   end
 
   desc 'Start up Solr & Fedora and run tests'

--- a/hydra-derivatives.gemspec
+++ b/hydra-derivatives.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency "solr_wrapper", "~> 2.0"
 
+  spec.add_dependency 'active-fedora', '>= 13.2.3'
   spec.add_dependency 'active_encode', '~>0.1'
   spec.add_dependency 'activesupport', '>= 4.0', '< 7'
   spec.add_dependency 'addressable', '~> 2.5'

--- a/hydra-derivatives.gemspec
+++ b/hydra-derivatives.gemspec
@@ -14,17 +14,17 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'fcrepo_wrapper', '~> 0.2'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rails', '> 5.1', '< 7.0'
   spec.add_development_dependency 'rake', '~> 10.1'
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency "solr_wrapper", "~> 2.0"
 
-  spec.add_dependency 'active-fedora', '>= 11.3.1', '< 14'
   spec.add_dependency 'active_encode', '~>0.1'
-  spec.add_dependency 'activesupport', '>= 4.0', '< 6'
-  spec.add_dependency 'addressable', '~>2.5'
+  spec.add_dependency 'activesupport', '>= 4.0', '< 7'
+  spec.add_dependency 'addressable', '~> 2.5'
   spec.add_dependency 'deprecation'
   spec.add_dependency 'mime-types', '> 2.0', '< 4.0'
   spec.add_dependency 'mini_magick', '>= 3.2', '< 5'

--- a/spec/processors/document_spec.rb
+++ b/spec/processors/document_spec.rb
@@ -30,7 +30,10 @@ describe Hydra::Derivatives::Processors::Document do
       let(:converted_file) { "path/to/converted.png" }
       let(:mock_content)   { "mocked png content" }
 
-      before { allow(File).to receive(:read).with(converted_file).and_return(mock_content) }
+      before do
+        allow(File).to receive(:open).with(converted_file, 'rb').and_return(mock_content)
+      end
+
       it "creates a thumbnail of the document" do
         expect(output_service).to receive(:call).with(mock_content, directives)
         expect(File).to receive(:unlink).with(converted_file)

--- a/spec/processors/full_text_spec.rb
+++ b/spec/processors/full_text_spec.rb
@@ -4,6 +4,11 @@ describe Hydra::Derivatives::Processors::FullText do
   let(:file_path)  { File.join(fixture_path, 'test.docx') }
   let(:directives) { { format: 'txt', url: RDF::URI('http://localhost:8983/fedora/rest/dev/1234/ogg') } }
   let(:processor)  { described_class.new(file_path, directives) }
+  let(:http_options) do
+    {
+      use_ssl: nil
+    }
+  end
 
   describe "#process" do
     it 'extracts fulltext and stores the results' do
@@ -36,7 +41,7 @@ describe Hydra::Derivatives::Processors::FullText do
 
       it "calls the extraction service" do
         expect(processor).to receive(:check_for_ssl)
-        expect(Net::HTTP).to receive(:start).with('example.com', 99).and_yield(req)
+        expect(Net::HTTP).to receive(:start).with('example.com', 99, http_options).and_yield(req)
         expect(Net::HTTP::Post).to receive(:new).with('/solr/update', "Content-Type" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Content-Length" => "24244").and_return(req)
         expect(req).to receive(:request).and_return(resp)
         expect(subject).to eq response_body
@@ -50,7 +55,7 @@ describe Hydra::Derivatives::Processors::FullText do
 
       it "calls the extraction service" do
         expect(processor).to receive(:check_for_ssl)
-        expect(Net::HTTP).to receive(:start).with('example.com', 99).and_yield(req)
+        expect(Net::HTTP).to receive(:start).with('example.com', 99, http_options).and_yield(req)
         expect(Net::HTTP::Post).to receive(:new).with('/solr/update', "Content-Type" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Content-Length" => "24244").and_return(req)
         expect(req).to receive(:request).and_return(resp)
         expect(subject).to eq response_utf8
@@ -62,7 +67,7 @@ describe Hydra::Derivatives::Processors::FullText do
 
       it "raises an error" do
         expect(processor).to receive(:check_for_ssl)
-        expect(Net::HTTP).to receive(:start).with('example.com', 99).and_yield(req)
+        expect(Net::HTTP).to receive(:start).with('example.com', 99, http_options).and_yield(req)
         expect(Net::HTTP::Post).to receive(:new).with('/solr/update', "Content-Type" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Content-Length" => "24244").and_return(req)
         expect(req).to receive(:request).and_return(resp)
         expect { subject }.to raise_error(RuntimeError, %r{^Solr Extract service was unsuccessful. 'https://example\.com:99/solr/update' returned code 500})
@@ -75,7 +80,7 @@ describe Hydra::Derivatives::Processors::FullText do
 
       it "calls the extraction service with basic auth" do
         expect(processor).to receive(:check_for_ssl)
-        expect(Net::HTTP).to receive(:start).with('example.com', 99).and_yield(req)
+        expect(Net::HTTP).to receive(:start).with('example.com', 99, http_options).and_yield(req)
         expect(Net::HTTP::Post).to receive(:new).with('/solr/update', "Content-Type" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Content-Length" => "24244").and_return(req)
         expect(req).to receive(:basic_auth).with('user', 'password')
         expect(req).to receive(:request).and_return(resp)
@@ -90,7 +95,7 @@ describe Hydra::Derivatives::Processors::FullText do
       it "raises a 401 error" do
         req.basic_auth(nil, nil)
         expect(processor).to receive(:check_for_ssl)
-        expect(Net::HTTP).to receive(:start).with('example.com', 99).and_yield(req)
+        expect(Net::HTTP).to receive(:start).with('example.com', 99, http_options).and_yield(req)
         expect(req).to receive(:request).and_return(resp)
         expect { subject }.to raise_error(RuntimeError, %r{^Solr Extract service was unsuccessful. 'https://user:password@example.com:99/solr/update' returned code 401})
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,7 @@ end
 # - RSpec adds ./lib to the $LOAD_PATH
 require 'hydra/derivatives'
 # Resque.inline = Rails.env.test?
-require 'byebug' unless ENV['TRAVIS']
+require 'pry-byebug' unless ENV['CI']
 
 require 'active_fedora/cleaner'
 ActiveFedora::Base.logger = Logger.new(STDOUT)


### PR DESCRIPTION
Supersedes #221 by removing active-fedora dependency pinning.