### PR TITLE
Allow active-fedora with pinned rdf-vocab

### DIFF
--- a/hydra-derivatives.gemspec
+++ b/hydra-derivatives.gemspec
@@ -22,7 +22,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency "solr_wrapper", "~> 2.0"
 
-  spec.add_dependency 'active-fedora', '>= 13.2.3'
+  spec.add_dependency 'active-fedora', '>= 11.5.6',
+                      '!= 12.0.0', '!= 12.0.1', '!= 12.0.2', '!= 12.0.3', '!= 12.1.0', '!= 12.1.1', '!= 12.2.0', '!= 12.2.1',
+                      '!= 13.0.0', '!= 13.1.0', '!= 13.1.1', '!= 13.1.2', '!= 13.1.3', '!= 13.2.0', '!= 13.2.1'
   spec.add_dependency 'active_encode', '~>0.1'
   spec.add_dependency 'activesupport', '>= 4.0', '< 7'
   spec.add_dependency 'addressable', '~> 2.5'


### PR DESCRIPTION
Co-Authored-By: Anna Headley <anna.headley@gmail.com>
Co-Authored-By: Chris Colvard <chris.colvard@gmail.com>

Keeps compatibility with active-fedora 11 and 12 versions that pin the rdf-vocab gem.