### PR TITLE
Updating the CircleCI configuration to check for a master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,15 @@ jobs:
     steps:
       - samvera/cached_checkout
       - run:
+          name: Check for a branch named 'master'
+          command: |
+            git fetch --all --quiet --prune --prune-tags
+            if [[ -n "$(git branch --all --list master */master)" ]]; then
+              echo "A branch named 'master' was found. Please remove it."
+              echo "$(git branch --all --list master */master)"
+            fi
+            [[ -z "$(git branch --all --list master */master)" ]]
+      - run:
           name: Install dependencies
           command: |
             sudo apt-get update


### PR DESCRIPTION
Fixes #228

This PR adds the Circle CI step that fails if the branch name is master.