### PR TITLE
Install kdu_compress from official source

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,14 +20,30 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt-get install ghostscript libpng-dev imagemagick ffmpeg libreoffice dcraw
-      - setup_remote_docker
+      - restore_cache:
+          name: Restore Kakadu Cache
+          keys:
+            - kakadu-cache-v1
+      - run:
+          name: Download Kakadu
+          command: |
+            if [ ! -f ~/downloads/kakadu.zip ]; then
+              mkdir -p ~/downloads
+              wget http://kakadusoftware.com/wp-content/uploads/KDU805_Demo_Apps_for_Linux-x86-64_200602.zip -O ~/downloads/kakadu.zip
+            fi
+      - save_cache:
+          name: Save Kakadu Cache
+          key: kakadu-cache-v1
+          paths:
+            - ~/downloads/kakadu.zip
       - run:
           name: Install Kakadu
           command: |
-            docker create --name kakadu josejuansanchez/kakadu:1.0
-            docker cp kakadu:/kakadu kakadu
+            unzip ~/downloads/kakadu.zip
+            mv KDU805_Demo_Apps_for_Linux-x86-64_200602 kakadu
             sudo cp kakadu/*.so /usr/lib
             sudo cp kakadu/* /usr/bin
+            kdu_compress -version
       - run:
           name: Modify ImageMagick security policy
           command: sudo sed -i 's/policy domain="coder" rights="none" pattern="PDF"/policy domain="coder" rights="read|write" pattern="PDF"/' /etc/ImageMagick-6/policy.xml


### PR DESCRIPTION
Reverts to previous method of making kdu_compress available in CI, with an updated url and added caching of the archive.