### PR TITLE
Remove Rails 6.1 restriction

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
       - samvera/bundle:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>
+          cache_version: "2"
 
       - samvera/install_solr_core
 

--- a/hydra-derivatives.gemspec
+++ b/hydra-derivatives.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
                       '!= 12.0.0', '!= 12.0.1', '!= 12.0.2', '!= 12.0.3', '!= 12.1.0', '!= 12.1.1', '!= 12.2.0', '!= 12.2.1',
                       '!= 13.0.0', '!= 13.1.0', '!= 13.1.1', '!= 13.1.2', '!= 13.1.3', '!= 13.2.0', '!= 13.2.1'
   spec.add_dependency 'active_encode', '~>0.1'
-  spec.add_dependency 'activemodel', '< 6.1'
   spec.add_dependency 'activesupport', '>= 4.0', '< 7'
   spec.add_dependency 'addressable', '~> 2.5'
   spec.add_dependency 'deprecation'


### PR DESCRIPTION
Now that there's a released AF version that supports 6.1, this should be
fine.