### PR TITLE
Introduces upgrades which ensures that Ruby 3.0.z releases are supported

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,14 +75,14 @@ workflows:
   ci:
     jobs:
       - bundle_lint_test:
+          name: ruby3-0
+          ruby_version: 3.0.3
+      - bundle_lint_test:
           name: ruby2-7
           ruby_version: 2.7.5
       - bundle_lint_test:
           name: ruby2-6
           ruby_version: 2.6.9
-      - bundle_lint_test:
-          name: ruby2-5
-          ruby_version: 2.5.9
 
   nightly:
     triggers:
@@ -94,11 +94,11 @@ workflows:
                 - main
     jobs:
       - bundle_lint_test:
+          name: ruby3-0
+          ruby_version: 3.0.3
+      - bundle_lint_test:
           name: ruby2-7
           ruby_version: 2.7.5
       - bundle_lint_test:
           name: ruby2-6
           ruby_version: 2.6.9
-      - bundle_lint_test:
-          name: ruby2-5
-          ruby_version: 2.5.9

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,0 +1,27 @@
+name: hydra_derivatives
+services:
+  fcrepo4:
+    type: compose
+    app_mount: false
+    portforward: true
+    volumes:
+      fcrepo4:
+    services:
+      image: samvera/fcrepo4:4.7.5
+      command: /fedora-entrypoint.sh
+      volumes:
+        - fcrepo4:/data
+      ports:
+        - 8986:8080
+  solr:
+    type: solr:7
+    app_mount: false
+    portforward: 8985
+    core: hydra-test
+    config:
+      dir: solr/config
+proxy:
+  fcrepo4:
+    - hydra-derivatives.fcrepo4.lndo.site:8986
+  solr:
+    - hydra-derivatives.solr.lndo.site:8985

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
-require: rubocop-rspec
+inherit_gem:
+    bixby: bixby_default.yml
 inherit_from: .rubocop_todo.yml
 
 AllCops:
@@ -12,7 +13,7 @@ AllCops:
     - Rakefile
 
 Layout/IndentationConsistency:
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
 
 Metrics/AbcSize:
   Max: 42

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'active-triples', git: 'https://github.com/samvera-labs/ActiveTriples.git', branch: 'issues-5-jrgriffiniii-rdf-3.2'
-gem 'active-fedora', git: 'https://github.com/samvera/active_fedora.git', branch: 'ruby3'
 
 # Please see hydra-derivatives.gemspec for dependency information.
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,16 @@
 source 'https://rubygems.org'
 
+gem 'active-triples', git: 'https://github.com/samvera-labs/ActiveTriples.git', branch: 'issues-5-jrgriffiniii-rdf-3.2'
+gem 'active-fedora', git: 'https://github.com/samvera/active_fedora.git', branch: 'ruby3'
+
 # Please see hydra-derivatives.gemspec for dependency information.
 gemspec
 
 gem 'sprockets', '~> 3.7'
 
 group :development, :test do
+  gem 'bixby'
   gem 'coveralls'
   gem 'rspec_junit_formatter'
-  gem 'rubocop', '~> 0.52.0', require: false
-  gem 'rubocop-rspec', require: false
   gem 'simplecov'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'active-triples', git: 'https://github.com/samvera-labs/ActiveTriples.git', branch: 'issues-5-jrgriffiniii-rdf-3.2'
-
 # Please see hydra-derivatives.gemspec for dependency information.
 gemspec
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,6 @@
 
 require "bundler/gem_tasks"
 
-# Dir.glob('tasks/*.rake').each { |r| import r }
-
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 

--- a/hydra-derivatives.gemspec
+++ b/hydra-derivatives.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "solr_wrapper"
 
   spec.add_dependency 'active_encode', '~> 0.1'
+  spec.add_dependency 'active-fedora', '>= 14.0'
   spec.add_dependency 'activesupport', '>= 4.0', '< 7.1'
   spec.add_dependency 'addressable', '~> 2.5'
   spec.add_dependency 'deprecation'

--- a/hydra-derivatives.gemspec
+++ b/hydra-derivatives.gemspec
@@ -22,10 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency "solr_wrapper", "~> 2.0"
 
-  spec.add_dependency 'active-fedora', '>= 11.5.6',
-                      '!= 12.0.0', '!= 12.0.1', '!= 12.0.2', '!= 12.0.3', '!= 12.1.0', '!= 12.1.1', '!= 12.2.0', '!= 12.2.1',
-                      '!= 13.0.0', '!= 13.1.0', '!= 13.1.1', '!= 13.1.2', '!= 13.1.3', '!= 13.2.0', '!= 13.2.1'
-  spec.add_dependency 'active_encode', '~>0.1'
+  spec.add_dependency 'active_encode', '~> 0.1'
   spec.add_dependency 'activesupport', '>= 4.0', '< 7'
   spec.add_dependency 'addressable', '~> 2.5'
   spec.add_dependency 'deprecation'

--- a/hydra-derivatives.gemspec
+++ b/hydra-derivatives.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'active_encode', '~> 0.1'
   spec.add_dependency 'active-fedora', '>= 14.0'
+  spec.add_dependency 'active-triples', '>= 1.2'
   spec.add_dependency 'activesupport', '>= 4.0', '< 7.1'
   spec.add_dependency 'addressable', '~> 2.5'
   spec.add_dependency 'deprecation'

--- a/lib/hydra/derivatives.rb
+++ b/lib/hydra/derivatives.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_fedora'
 require 'deprecation'
 

--- a/lib/hydra/derivatives/audio_encoder.rb
+++ b/lib/hydra/derivatives/audio_encoder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'open3'
 
 module Hydra::Derivatives

--- a/lib/hydra/derivatives/config.rb
+++ b/lib/hydra/derivatives/config.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'tmpdir'
 
 module Hydra

--- a/lib/hydra/derivatives/io_decorator.rb
+++ b/lib/hydra/derivatives/io_decorator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Naive implementation of IO wrapper class that adds mime_type and original_filename
 # attributes. This is done to match the interface of ActionDispatch::HTTP::UploadedFile
 # so the attributes do not have to be passed as additional arguments, and are attached
@@ -16,7 +17,7 @@ module Hydra
       alias original_name original_filename
       deprecation_deprecate original_name: 'original_name has been deprecated. Use original_filename instead. This will be removed in hydra-derivatives 4.0'
       alias original_name= original_filename=
-      deprecation_deprecate :"original_name=" => 'original_name= has been deprecated. Use original_filename= instead. This will be removed in hydra-derivatives 4.0'
+      deprecation_deprecate "original_name=": 'original_name= has been deprecated. Use original_filename= instead. This will be removed in hydra-derivatives 4.0'
 
       def initialize(file, mime_type = nil, original_filename = nil)
         super(file)

--- a/lib/hydra/derivatives/logger.rb
+++ b/lib/hydra/derivatives/logger.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra::Derivatives
   class Logger
     class << self
@@ -17,9 +18,9 @@ module Hydra::Derivatives
 
       private
 
-      def logger
-        ActiveFedora::Base.logger || ::Logger.new(STDOUT)
-      end
+        def logger
+          ActiveFedora::Base.logger || ::Logger.new(STDOUT)
+        end
     end
   end
 end

--- a/lib/hydra/derivatives/processors.rb
+++ b/lib/hydra/derivatives/processors.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra::Derivatives
   module Processors
     extend ActiveSupport::Autoload

--- a/lib/hydra/derivatives/processors/active_encode.rb
+++ b/lib/hydra/derivatives/processors/active_encode.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_encode'
 
 module Hydra::Derivatives::Processors

--- a/lib/hydra/derivatives/processors/audio.rb
+++ b/lib/hydra/derivatives/processors/audio.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra::Derivatives::Processors
   class Audio < Processor
     include Ffmpeg

--- a/lib/hydra/derivatives/processors/ffmpeg.rb
+++ b/lib/hydra/derivatives/processors/ffmpeg.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # An abstract class for asyncronous jobs that transcode files using FFMpeg
 module Hydra::Derivatives::Processors
   module Ffmpeg

--- a/lib/hydra/derivatives/processors/image.rb
+++ b/lib/hydra/derivatives/processors/image.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mini_magick'
 
 module Hydra::Derivatives::Processors
@@ -61,7 +62,7 @@ module Hydra::Derivatives::Processors
       end
 
       def selected_layers(image)
-        if image.type =~ /pdf/i
+        if /pdf/i.match?(image.type)
           image.layers[directives.fetch(:layer, 0)]
         elsif directives.fetch(:layer, false)
           image.layers[directives.fetch(:layer)]

--- a/lib/hydra/derivatives/processors/jpeg2k_image.rb
+++ b/lib/hydra/derivatives/processors/jpeg2k_image.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mini_magick'
 require 'nokogiri'
 
@@ -90,9 +91,7 @@ module Hydra::Derivatives::Processors
       long_dim = self.class.long_dim(image)
       file_path = self.class.tmp_file('.tif')
       to_srgb = directives.fetch(:to_srgb, true)
-      if directives[:resize] || to_srgb
-        preprocess(image, resize: directives[:resize], to_srgb: to_srgb, src_quality: quality)
-      end
+      preprocess(image, resize: directives[:resize], to_srgb: to_srgb, src_quality: quality) if directives[:resize] || to_srgb
       image.write file_path
       recipe = self.class.kdu_compress_recipe(directives, quality, long_dim)
       encode_file(recipe, file_path: file_path)

--- a/lib/hydra/derivatives/processors/processor.rb
+++ b/lib/hydra/derivatives/processors/processor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra::Derivatives::Processors
   # Processors take a single input and produce a single output
   class Processor

--- a/lib/hydra/derivatives/processors/raw_image.rb
+++ b/lib/hydra/derivatives/processors/raw_image.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mini_magick'
 
 module Hydra::Derivatives::Processors

--- a/lib/hydra/derivatives/processors/video.rb
+++ b/lib/hydra/derivatives/processors/video.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra::Derivatives::Processors
   module Video
     extend ActiveSupport::Autoload

--- a/lib/hydra/derivatives/processors/video/config.rb
+++ b/lib/hydra/derivatives/processors/video/config.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra::Derivatives::Processors::Video
   class Config
     attr_writer :video_bitrate, :video_attributes, :size_attributes, :audio_attributes

--- a/lib/hydra/derivatives/processors/video/processor.rb
+++ b/lib/hydra/derivatives/processors/video/processor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra::Derivatives::Processors
   module Video
     class Processor < Hydra::Derivatives::Processors::Processor

--- a/lib/hydra/derivatives/runners/active_encode_derivatives.rb
+++ b/lib/hydra/derivatives/runners/active_encode_derivatives.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra::Derivatives
   class ActiveEncodeDerivatives < Runner
     # @param [String, ActiveFedora::Base] object_or_filename source file name (or path), or an object that has a method that will return the file name

--- a/lib/hydra/derivatives/runners/audio_derivatives.rb
+++ b/lib/hydra/derivatives/runners/audio_derivatives.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra::Derivatives
   class AudioDerivatives < Runner
     def self.processor_class

--- a/lib/hydra/derivatives/runners/document_derivatives.rb
+++ b/lib/hydra/derivatives/runners/document_derivatives.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra::Derivatives
   class DocumentDerivatives < Runner
     def self.processor_class

--- a/lib/hydra/derivatives/runners/full_text_extract.rb
+++ b/lib/hydra/derivatives/runners/full_text_extract.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra::Derivatives
   class FullTextExtract < ImageDerivatives
     # Adds format: 'txt' as the default to each of the directives

--- a/lib/hydra/derivatives/runners/image_derivatives.rb
+++ b/lib/hydra/derivatives/runners/image_derivatives.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra::Derivatives
   class ImageDerivatives < Runner
     # Adds format: 'png' as the default to each of the directives

--- a/lib/hydra/derivatives/runners/jpeg2k_image_derivatives.rb
+++ b/lib/hydra/derivatives/runners/jpeg2k_image_derivatives.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra::Derivatives
   class Jpeg2kImageDerivatives < Runner
     # # Adds format: 'png' as the default to each of the directives

--- a/lib/hydra/derivatives/runners/pdf_derivatives.rb
+++ b/lib/hydra/derivatives/runners/pdf_derivatives.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra
   module Derivatives
     class PdfDerivatives < ImageDerivatives

--- a/lib/hydra/derivatives/runners/runner.rb
+++ b/lib/hydra/derivatives/runners/runner.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra
   module Derivatives
     class Runner

--- a/lib/hydra/derivatives/runners/video_derivatives.rb
+++ b/lib/hydra/derivatives/runners/video_derivatives.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra::Derivatives
   class VideoDerivatives < Runner
     def self.processor_class

--- a/lib/hydra/derivatives/services/capability_service.rb
+++ b/lib/hydra/derivatives/services/capability_service.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'open3'
 
 module Hydra::Derivatives

--- a/lib/hydra/derivatives/services/mime_type_service.rb
+++ b/lib/hydra/derivatives/services/mime_type_service.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mime/types'
 
 module Hydra::Derivatives

--- a/lib/hydra/derivatives/services/persist_basic_contained_output_file_service.rb
+++ b/lib/hydra/derivatives/services/persist_basic_contained_output_file_service.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra::Derivatives
   # This Service is an implementation of the Hydra::Derivatives::PeristOutputFileService
   # It supports basic contained files, which is the behavior associated with Fedora 3 file datastreams that were migrated to Fedora 4

--- a/lib/hydra/derivatives/services/persist_external_file_output_file_service.rb
+++ b/lib/hydra/derivatives/services/persist_external_file_output_file_service.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'addressable'
 
 module Hydra::Derivatives

--- a/lib/hydra/derivatives/services/persist_output_file_service.rb
+++ b/lib/hydra/derivatives/services/persist_output_file_service.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra::Derivatives
   class PersistOutputFileService
     # Persists the file within the object at destination_name.  Uses basic containment.

--- a/lib/hydra/derivatives/services/remote_source_file.rb
+++ b/lib/hydra/derivatives/services/remote_source_file.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # For the case where the source file is a remote file, and we
 # don't want to download the file locally, just return the
 # file name or file path (or whatever we need to pass to the

--- a/lib/hydra/derivatives/services/retrieve_source_file_service.rb
+++ b/lib/hydra/derivatives/services/retrieve_source_file_service.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hydra::Derivatives
   class RetrieveSourceFileService
     # Retrieves the source

--- a/lib/hydra/derivatives/services/tempfile_service.rb
+++ b/lib/hydra/derivatives/services/tempfile_service.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mime/types'
 
 module Hydra::Derivatives

--- a/spec/processors/active_encode_spec.rb
+++ b/spec/processors/active_encode_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Hydra::Derivatives::Processors::ActiveEncode do

--- a/spec/processors/document_spec.rb
+++ b/spec/processors/document_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Hydra::Derivatives::Processors::Document do

--- a/spec/processors/full_text_spec.rb
+++ b/spec/processors/full_text_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Hydra::Derivatives::Processors::FullText do
@@ -42,7 +43,7 @@ describe Hydra::Derivatives::Processors::FullText do
       it "calls the extraction service" do
         expect(processor).to receive(:check_for_ssl)
         expect(Net::HTTP).to receive(:start).with('example.com', 99, http_options).and_yield(req)
-        expect(Net::HTTP::Post).to receive(:new).with('/solr/update', "Content-Type" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Content-Length" => "24244").and_return(req)
+        expect(Net::HTTP::Post).to receive(:new).with('/solr/update', { "Content-Type" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Content-Length" => "24244" }).and_return(req)
         expect(req).to receive(:request).and_return(resp)
         expect(subject).to eq response_body
       end
@@ -56,7 +57,7 @@ describe Hydra::Derivatives::Processors::FullText do
       it "calls the extraction service" do
         expect(processor).to receive(:check_for_ssl)
         expect(Net::HTTP).to receive(:start).with('example.com', 99, http_options).and_yield(req)
-        expect(Net::HTTP::Post).to receive(:new).with('/solr/update', "Content-Type" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Content-Length" => "24244").and_return(req)
+        expect(Net::HTTP::Post).to receive(:new).with('/solr/update', { "Content-Type" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Content-Length" => "24244" }).and_return(req)
         expect(req).to receive(:request).and_return(resp)
         expect(subject).to eq response_utf8
       end
@@ -68,7 +69,7 @@ describe Hydra::Derivatives::Processors::FullText do
       it "raises an error" do
         expect(processor).to receive(:check_for_ssl)
         expect(Net::HTTP).to receive(:start).with('example.com', 99, http_options).and_yield(req)
-        expect(Net::HTTP::Post).to receive(:new).with('/solr/update', "Content-Type" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Content-Length" => "24244").and_return(req)
+        expect(Net::HTTP::Post).to receive(:new).with('/solr/update', { "Content-Type" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Content-Length" => "24244" }).and_return(req)
         expect(req).to receive(:request).and_return(resp)
         expect { subject }.to raise_error(RuntimeError, %r{^Solr Extract service was unsuccessful. 'https://example\.com:99/solr/update' returned code 500})
       end
@@ -81,7 +82,7 @@ describe Hydra::Derivatives::Processors::FullText do
       it "calls the extraction service with basic auth" do
         expect(processor).to receive(:check_for_ssl)
         expect(Net::HTTP).to receive(:start).with('example.com', 99, http_options).and_yield(req)
-        expect(Net::HTTP::Post).to receive(:new).with('/solr/update', "Content-Type" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Content-Length" => "24244").and_return(req)
+        expect(Net::HTTP::Post).to receive(:new).with('/solr/update', { "Content-Type" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Content-Length" => "24244" }).and_return(req)
         expect(req).to receive(:basic_auth).with('user', 'password')
         expect(req).to receive(:request).and_return(resp)
         expect(subject).to eq response_body

--- a/spec/processors/image_spec.rb
+++ b/spec/processors/image_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Hydra::Derivatives::Processors::Image do

--- a/spec/processors/jpeg2k_spec.rb
+++ b/spec/processors/jpeg2k_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 require 'yaml'
 
@@ -28,7 +29,9 @@ describe Hydra::Derivatives::Processors::Jpeg2kImage do
 
   describe "#kdu_compress_recipe" do
     before(:all) do
-      @sample_cfg = YAML.load_file(File.expand_path('../../fixtures/jpeg2k_config.yml', __FILE__))['test']
+      @sample_cfg_path = File.expand_path('../../fixtures/jpeg2k_config.yml', __FILE__)
+      @sample_cfg_yaml = YAML.load_file(@sample_cfg_path, aliases: true)
+      @sample_cfg = @sample_cfg_yaml['test']
       Hydra::Derivatives.kdu_compress_recipes = @sample_cfg['jp2_recipes']
     end
     after(:all) do

--- a/spec/processors/processor_spec.rb
+++ b/spec/processors/processor_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Hydra::Derivatives::Processors::Processor do

--- a/spec/processors/shell_based_processor_spec.rb
+++ b/spec/processors/shell_based_processor_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Hydra::Derivatives::Processors::ShellBasedProcessor do

--- a/spec/processors/video_spec.rb
+++ b/spec/processors/video_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Hydra::Derivatives::Processors::Video::Processor do
@@ -15,7 +16,7 @@ describe Hydra::Derivatives::Processors::Video::Processor do
     let(:directives) { { label: :thumb, format: "mp4", url: 'http://localhost:8983/fedora/rest/dev/1234/thumbnail' } }
 
     it "is configurable" do
-      expect(subject).to receive(:encode_file).with("mp4", Hydra::Derivatives::Processors::Ffmpeg::OUTPUT_OPTIONS => "-s 320x240 -vcodec mpeg4 -acodec aac -strict -2 -g 30 -b:v 345k -ac 2 -ab 96k -ar 44100", Hydra::Derivatives::Processors::Ffmpeg::INPUT_OPTIONS => "")
+      expect(subject).to receive(:encode_file).with("mp4", { Hydra::Derivatives::Processors::Ffmpeg::OUTPUT_OPTIONS => "-s 320x240 -vcodec mpeg4 -acodec aac -strict -2 -g 30 -b:v 345k -ac 2 -ab 96k -ar 44100", Hydra::Derivatives::Processors::Ffmpeg::INPUT_OPTIONS => "" })
       subject.process
     end
   end
@@ -25,7 +26,7 @@ describe Hydra::Derivatives::Processors::Video::Processor do
       let(:directives) { { label: :thumb, format: 'webm', url: 'http://localhost:8983/fedora/rest/dev/1234/thumbnail' } }
 
       it "creates a fedora resource and infers the name" do
-        expect(subject).to receive(:encode_file).with("webm", Hydra::Derivatives::Processors::Ffmpeg::OUTPUT_OPTIONS => "-s 320x240 -vcodec libvpx -acodec libvorbis -g 30 -b:v 345k -ac 2 -ab 96k -ar 44100", Hydra::Derivatives::Processors::Ffmpeg::INPUT_OPTIONS => "")
+        expect(subject).to receive(:encode_file).with("webm", { Hydra::Derivatives::Processors::Ffmpeg::OUTPUT_OPTIONS => "-s 320x240 -vcodec libvpx -acodec libvorbis -g 30 -b:v 345k -ac 2 -ab 96k -ar 44100", Hydra::Derivatives::Processors::Ffmpeg::INPUT_OPTIONS => "" })
         subject.process
       end
     end
@@ -34,7 +35,7 @@ describe Hydra::Derivatives::Processors::Video::Processor do
       let(:directives) { { label: :thumb, format: 'jpg', url: 'http://localhost:8983/fedora/rest/dev/1234/thumbnail' } }
 
       it "creates a fedora resource and infers the name" do
-        expect(subject).to receive(:encode_file).with("jpg", output_options: "-s 320x240 -vcodec mjpeg -vframes 1 -an -f rawvideo", input_options: " -itsoffset -2")
+        expect(subject).to receive(:encode_file).with("jpg", { output_options: "-s 320x240 -vcodec mjpeg -vframes 1 -an -f rawvideo", input_options: " -itsoffset -2" })
         subject.process
       end
     end
@@ -43,7 +44,7 @@ describe Hydra::Derivatives::Processors::Video::Processor do
       let(:directives) { { label: :thumb, format: 'mkv', url: 'http://localhost:8983/fedora/rest/dev/1234/thumbnail' } }
 
       it "creates a fedora resource and infers the name" do
-        expect(subject).to receive(:encode_file).with("mkv", Hydra::Derivatives::Processors::Ffmpeg::OUTPUT_OPTIONS => "-s 320x240 -vcodec ffv1 -g 30 -b:v 345k -ac 2 -ab 96k -ar 44100", Hydra::Derivatives::Processors::Ffmpeg::INPUT_OPTIONS => "")
+        expect(subject).to receive(:encode_file).with("mkv", { Hydra::Derivatives::Processors::Ffmpeg::OUTPUT_OPTIONS => "-s 320x240 -vcodec ffv1 -g 30 -b:v 345k -ac 2 -ab 96k -ar 44100", Hydra::Derivatives::Processors::Ffmpeg::INPUT_OPTIONS => "" })
         subject.process
       end
     end
@@ -60,7 +61,7 @@ describe Hydra::Derivatives::Processors::Video::Processor do
       let(:directives) { { label: :thumbnail, format: 'mp4', url: 'http://localhost:8983/fedora/rest/dev/1234/thumbnail', bitrate: "4000k" } }
 
       it "creates a fedora resource and infers the name" do
-        expect(subject).to receive(:encode_file).with("mp4", Hydra::Derivatives::Processors::Ffmpeg::OUTPUT_OPTIONS => "-s 320x240 -vcodec libx264 -acodec aac -g 30 -b:v 4000k -ac 2 -ab 96k -ar 44100", Hydra::Derivatives::Processors::Ffmpeg::INPUT_OPTIONS => "")
+        expect(subject).to receive(:encode_file).with("mp4", { Hydra::Derivatives::Processors::Ffmpeg::OUTPUT_OPTIONS => "-s 320x240 -vcodec libx264 -acodec aac -g 30 -b:v 4000k -ac 2 -ab 96k -ar 44100", Hydra::Derivatives::Processors::Ffmpeg::INPUT_OPTIONS => "" })
         subject.process
       end
     end
@@ -69,7 +70,7 @@ describe Hydra::Derivatives::Processors::Video::Processor do
       let(:directives) { { label: :thumbnail, format: 'mp4', url: 'http://localhost:8983/fedora/rest/dev/1234/thumbnail', size: "1080x720", input_options: "-t 10 -ss 1", video: "-g 30 -b:v 4000k", audio: "-b:a 256k -ar 44100" } }
 
       it "creates a fedora resource and infers the name" do
-        expect(subject).to receive(:encode_file).with("mp4", Hydra::Derivatives::Processors::Ffmpeg::OUTPUT_OPTIONS => "-s 1080x720 -vcodec libx264 -acodec aac -g 30 -b:v 4000k -b:a 256k -ar 44100", Hydra::Derivatives::Processors::Ffmpeg::INPUT_OPTIONS => "-t 10 -ss 1")
+        expect(subject).to receive(:encode_file).with("mp4", { Hydra::Derivatives::Processors::Ffmpeg::OUTPUT_OPTIONS => "-s 1080x720 -vcodec libx264 -acodec aac -g 30 -b:v 4000k -b:a 256k -ar 44100", Hydra::Derivatives::Processors::Ffmpeg::INPUT_OPTIONS => "-t 10 -ss 1" })
         subject.process
       end
     end

--- a/spec/runners/active_encode_derivatives_spec.rb
+++ b/spec/runners/active_encode_derivatives_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Hydra::Derivatives::ActiveEncodeDerivatives do
@@ -17,7 +18,7 @@ describe Hydra::Derivatives::ActiveEncodeDerivatives do
     let(:processor) { instance_double('processor') }
 
     it 'calls the processor with the right arguments' do
-      expect(Hydra::Derivatives::Processors::ActiveEncode).to receive(:new).with(file_path, low_res_video, output_file_service: Hydra::Derivatives::PersistExternalFileOutputFileService).and_return(processor)
+      expect(Hydra::Derivatives::Processors::ActiveEncode).to receive(:new).with(file_path, low_res_video, { output_file_service: Hydra::Derivatives::PersistExternalFileOutputFileService }).and_return(processor)
       expect(processor).to receive(:process)
       described_class.create(video_record, options)
     end
@@ -29,7 +30,7 @@ describe Hydra::Derivatives::ActiveEncodeDerivatives do
       let(:options) { { encode_class: TestEncode, source: :remote_file_name, outputs: [low_res_video] } }
 
       it 'calls the processor with the right arguments' do
-        expect(Hydra::Derivatives::Processors::ActiveEncode).to receive(:new).with(file_path, low_res_video, output_file_service: Hydra::Derivatives::PersistExternalFileOutputFileService, encode_class: TestEncode).and_return(processor)
+        expect(Hydra::Derivatives::Processors::ActiveEncode).to receive(:new).with(file_path, low_res_video, { output_file_service: Hydra::Derivatives::PersistExternalFileOutputFileService, encode_class: TestEncode }).and_return(processor)
         expect(processor).to receive(:process)
         described_class.create(video_record, options)
       end

--- a/spec/runners/runner_spec.rb
+++ b/spec/runners/runner_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe Hydra::Derivatives::Runner do

--- a/spec/services/audio_derivatives_spec.rb
+++ b/spec/services/audio_derivatives_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Hydra::Derivatives::AudioDerivatives do
@@ -29,7 +30,7 @@ describe Hydra::Derivatives::AudioDerivatives do
     end
 
     context "with an object" do
-      let(:object)      { "Fake Object" }
+      let(:object)      { double }
       let(:source_name) { :content }
       let(:file)        { instance_double("the file") }
 
@@ -51,7 +52,7 @@ describe Hydra::Derivatives::AudioDerivatives do
     subject { described_class }
 
     it "relies on the source_file_service" do
-      expect(subject.source_file_service).to receive(:call).with('foo/bar.aiff', baz: true)
+      expect(subject.source_file_service).to receive(:call).with('foo/bar.aiff', { baz: true })
       subject.source_file('foo/bar.aiff', baz: true)
     end
   end

--- a/spec/services/persist_basic_contained_output_file_service_spec.rb
+++ b/spec/services/persist_basic_contained_output_file_service_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Hydra::Derivatives::PersistBasicContainedOutputFileService do

--- a/spec/services/persist_external_file_output_file_service_spec.rb
+++ b/spec/services/persist_external_file_output_file_service_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Hydra::Derivatives::PersistExternalFileOutputFileService do

--- a/spec/services/persist_output_file_service_spec.rb
+++ b/spec/services/persist_output_file_service_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 RSpec.describe Hydra::Derivatives::PersistOutputFileService do

--- a/spec/services/remote_source_file_spec.rb
+++ b/spec/services/remote_source_file_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 class TestObject < ActiveFedora::Base

--- a/spec/services/retrieve_source_file_service_spec.rb
+++ b/spec/services/retrieve_source_file_service_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Hydra::Derivatives::RetrieveSourceFileService do

--- a/spec/services/tempfile_service_spec.rb
+++ b/spec/services/tempfile_service_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Hydra::Derivatives::TempfileService do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV['environment'] ||= 'test'
 ENV['RAILS_ENV'] = 'test'
 

--- a/spec/units/audio_encoder_spec.rb
+++ b/spec/units/audio_encoder_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Hydra::Derivatives::AudioEncoder do

--- a/spec/units/config_spec.rb
+++ b/spec/units/config_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe "the configuration" do

--- a/spec/units/derivatives_spec.rb
+++ b/spec/units/derivatives_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Hydra::Derivatives do

--- a/spec/units/io_decorator_spec.rb
+++ b/spec/units/io_decorator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 require 'stringio'
 

--- a/spec/units/logger_spec.rb
+++ b/spec/units/logger_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Hydra::Derivatives::Logger do

--- a/spec/units/transcoding_spec.rb
+++ b/spec/units/transcoding_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe "Transcoding" do


### PR DESCRIPTION
Resolves #234. This is also currently blocked by the following:

- https://github.com/samvera/active_fedora/pull/1489
- https://github.com/samvera-labs/ActiveTriples/pull/9