### PR TITLE
rescue IO::EAGAINWaitReadable errors

### DIFF
--- a/lib/hydra/derivatives/processors/shell_based_processor.rb
+++ b/lib/hydra/derivatives/processors/shell_based_processor.rb
@@ -83,6 +83,10 @@ module Hydra::Derivatives::Processors
                 updated_error_buffer << data
                 error_buffer = updated_error_buffer
               end
+            rescue IO::WaitReadable
+              Hydra::Derivatives::Logger.warn "Caught an IO::WaitReadable error in ShellBasedProcessor. Retrying..."
+              IO.select([f], nil, nil, 60)
+              retry
             rescue EOFError
               Hydra::Derivatives::Logger.debug "Caught an eof error in ShellBasedProcessor"
               # No big deal.

--- a/spec/processors/shell_based_processor_spec.rb
+++ b/spec/processors/shell_based_processor_spec.rb
@@ -26,8 +26,7 @@ describe Hydra::Derivatives::Processors::ShellBasedProcessor do
       end
     end
   end
-  
-  
+
   context "when a IO::EAGAINWaitReadable error occurs" do
     before do
       expect(TestProcessor).to receive(:popen3).and_wrap_original do |m, *args|


### PR DESCRIPTION
Fixes #251 

Adds handling of IO::WaitReadable errors (such as IO::EAGAINWaitReadable) in the manner suggested by IO#read_nonblock documentation. The existing use of IO.select appears able to fail when only one of stdout or stderr is ready. Each file will now be retried if the read is not ready.