### PR TITLE
Remove coveralls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem 'sprockets', '~> 3.7'
 
 group :development, :test do
   gem 'bixby'
-  gem 'coveralls'
   gem 'rspec_junit_formatter'
   gem 'simplecov'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,12 +3,10 @@ ENV['environment'] ||= 'test'
 ENV['RAILS_ENV'] = 'test'
 
 require 'simplecov'
-require 'coveralls'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
   [
-    SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter
+    SimpleCov::Formatter::HTMLFormatter
   ]
 )
 SimpleCov.minimum_coverage 100


### PR DESCRIPTION
Coveralls is breaking the CircleCI build for #252  and has been flakey for a long time now.  This PR proposes dropping coveralls like has been done in other samvera repos (e.g. https://github.com/samvera/browse-everything/pull/401).