### PR TITLE
Use Lando when running spec tests

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -45,6 +45,10 @@ RSpec/PredicateMatcher:
   Exclude:
     - spec/**/*.rb
 
+Rails/RakeEnvironment:
+  Exclude:
+    - 'tasks/dev.rake'
+
 RSpec/ReturnFromStub:
   Exclude:
     - spec/processors/jpeg2k_spec.rb

--- a/README.md
+++ b/README.md
@@ -244,14 +244,23 @@ Instead, each directive may contain these arguments:
 
 ## Running Tests
 
-1. Run tests with `RAILS_ENV=test bundle exec rake ci`
+For ease of development we use Lando to abstract away some complications of
+using Docker containers for development.
 
-## Running specific tests
+1. Install the latest released > 3.0 version of Lando from [here](https://github.com/lando/lando/releases).
+2. `bundle install`(Ruby 2.6+ required)
+3. `bundle exec rake server:start`
+4. `bundle exec rspec spec`
 
-If you don't want to run the whole suite all at once like CI, do the following:
+### Cleaning Data
 
-1. Run the test servers with `rake derivatives:test_server`
-2. Run the tests.
+1. `bundle exec rake server:clean`
+
+### Stopping Servers
+
+1. `bundle exec rake server:stop`
+
+You can also run `lando poweroff` from anywhere.
 
 # Acknowledgments
 

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,7 @@ require 'solr_wrapper/rake_task'
 require 'fcrepo_wrapper'
 require 'active_fedora/rake_support'
 require 'rubocop/rake_task'
+load 'tasks/dev.rake'
 
 namespace :derivatives do
   desc 'Run style checker'

--- a/tasks/dev.rake
+++ b/tasks/dev.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+namespace :server do
+  desc "Start solr and fedora servers for testing"
+  task :start do
+    require 'rails'
+    `lando start`
+    puts "Started Solr/Fedora"
+  end
+
+  desc "Cleanup test servers"
+  task :clean do
+    require 'rails'
+    `lando destroy -y`
+    `lando start`
+    puts "Cleaned/Started Solr/Fedora"
+  end
+
+  desc "Stop test servers"
+  task :stop do
+    `lando stop -y`
+  end
+end


### PR DESCRIPTION
Was unable to run tests locally using fcrepo_wrapper so would like to switch to Lando instead for Fedora and Solr dependencies, #256 