### PR TITLE
add pix_fmt yuv420p to mp4 config

### DIFF
--- a/lib/hydra/derivatives/processors/video/config.rb
+++ b/lib/hydra/derivatives/processors/video/config.rb
@@ -21,7 +21,7 @@ module Hydra::Derivatives::Processors::Video
 
     def mpeg4
       audio_encoder = Hydra::Derivatives::AudioEncoder.new
-      @mpeg4 ||= CodecConfig.new("-vcodec libx264 -pix_fmt yuv420p -acodec #{audio_encoder.audio_encoder}")
+      @mpeg4 ||= CodecConfig.new("-vcodec libx264 -profile:v high -pix_fmt yuv420p -acodec #{audio_encoder.audio_encoder}")
     end
 
     def webm

--- a/lib/hydra/derivatives/processors/video/config.rb
+++ b/lib/hydra/derivatives/processors/video/config.rb
@@ -21,7 +21,7 @@ module Hydra::Derivatives::Processors::Video
 
     def mpeg4
       audio_encoder = Hydra::Derivatives::AudioEncoder.new
-      @mpeg4 ||= CodecConfig.new("-vcodec libx264 -acodec #{audio_encoder.audio_encoder}")
+      @mpeg4 ||= CodecConfig.new("-vcodec libx264 -pix_fmt yuv420p -acodec #{audio_encoder.audio_encoder}")
     end
 
     def webm

--- a/spec/processors/video_spec.rb
+++ b/spec/processors/video_spec.rb
@@ -61,7 +61,7 @@ describe Hydra::Derivatives::Processors::Video::Processor do
       let(:directives) { { label: :thumbnail, format: 'mp4', url: 'http://localhost:8983/fedora/rest/dev/1234/thumbnail', bitrate: "4000k" } }
 
       it "creates a fedora resource and infers the name" do
-        expect(subject).to receive(:encode_file).with("mp4", { Hydra::Derivatives::Processors::Ffmpeg::OUTPUT_OPTIONS => "-s 320x240 -vcodec libx264 -acodec aac -g 30 -b:v 4000k -ac 2 -ab 96k -ar 44100", Hydra::Derivatives::Processors::Ffmpeg::INPUT_OPTIONS => "" })
+        expect(subject).to receive(:encode_file).with("mp4", { Hydra::Derivatives::Processors::Ffmpeg::OUTPUT_OPTIONS => "-s 320x240 -vcodec libx264 -profile:v high -pix_fmt yuv420p -acodec aac -g 30 -b:v 4000k -ac 2 -ab 96k -ar 44100", Hydra::Derivatives::Processors::Ffmpeg::INPUT_OPTIONS => "" })
         subject.process
       end
     end
@@ -70,7 +70,7 @@ describe Hydra::Derivatives::Processors::Video::Processor do
       let(:directives) { { label: :thumbnail, format: 'mp4', url: 'http://localhost:8983/fedora/rest/dev/1234/thumbnail', size: "1080x720", input_options: "-t 10 -ss 1", video: "-g 30 -b:v 4000k", audio: "-b:a 256k -ar 44100" } }
 
       it "creates a fedora resource and infers the name" do
-        expect(subject).to receive(:encode_file).with("mp4", { Hydra::Derivatives::Processors::Ffmpeg::OUTPUT_OPTIONS => "-s 1080x720 -vcodec libx264 -acodec aac -g 30 -b:v 4000k -b:a 256k -ar 44100", Hydra::Derivatives::Processors::Ffmpeg::INPUT_OPTIONS => "-t 10 -ss 1" })
+        expect(subject).to receive(:encode_file).with("mp4", { Hydra::Derivatives::Processors::Ffmpeg::OUTPUT_OPTIONS => "-s 1080x720 -vcodec libx264 -profile:v high -pix_fmt yuv420p -acodec aac -g 30 -b:v 4000k -b:a 256k -ar 44100", Hydra::Derivatives::Processors::Ffmpeg::INPUT_OPTIONS => "-t 10 -ss 1" })
         subject.process
       end
     end


### PR DESCRIPTION
I've detected that in the case of video derivatives, specifically with the .mp4 extension, if the source video has the yuv422p color profile, the derived video cannot be viewed on mobile phones. To solve this, it is proposed to force the conversion to yuv420p.