### PR TITLE
Add libvips support for image derivatives and update Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           command: |
             wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
             sudo apt-get update
-            sudo apt-get install ghostscript libpng-dev imagemagick graphicsmagick ffmpeg libreoffice dcraw
+            sudo apt-get install ghostscript libpng-dev imagemagick graphicsmagick libvips libvips-dev libvips-tools ffmpeg libreoffice dcraw
       - restore_cache:
           name: Restore Kakadu Cache
           keys:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN apt update && apt -y install \
   zip \
   ghostscript \
   libpng-dev \
+  libvips \
+  libvips-dev \
+  libvips-tools \
   graphicsmagick \
   ffmpeg \
   libreoffice \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,11 @@ RUN apt update && apt -y install \
   dcraw \
   libyaml-dev
 
-RUN mkdir -p /opt/kakadu/downloads
-RUN wget http://kakadusoftware.com/wp-content/uploads/KDU805_Demo_Apps_for_Linux-x86-64_200602.zip -O /opt/kakadu/downloads/kakadu.zip \
-    && unzip /opt/kakadu/downloads/kakadu.zip \
-    && mv KDU805_Demo_Apps_for_Linux-x86-64_200602 kakadu \
+ARG KAKADU_ZIP
+RUN mkdir -p /opt/kakadu
+COPY $KAKADU_ZIP.zip /opt/kakadu/downloads/kakadu.zip
+RUN unzip /opt/kakadu/downloads/kakadu.zip \
+    && mv $KAKADU_ZIP kakadu \
     && cp kakadu/*.so /usr/lib \
     && cp kakadu/* /usr/bin
 

--- a/README.md
+++ b/README.md
@@ -257,10 +257,18 @@ If you don't want to run the whole suite all at once like CI, do the following:
 
 First, make sure you have installed [Docker](https://www.docker.com/).
 
-Within your cloned repository, tell Docker to get started installing your development environment:
+Download the most recent version of the Linux Kakadu demo from [the downloads page](https://kakadusoftware.com/documentation-downloads/downloads/)
+and place it in your cloned repository. (This requires signing up with an email address.)
+
+Note the name of the zip file without the .zip extension. We will pass this name as an argument when building 
+the docker container. For example, if the name of the zip file is `KDU841_Demo_Apps_for_Linux-x86-64_231117.zip`, 
+we will pass `KDU841_Demo_Apps_for_Linux-x86-64_231117` to `docker compose build`.
+
+Within your cloned repository, tell Docker to get started installing your development environment, replacing 
+`<name of zip file>` with the name of your downloaded file above.
 
 ```sh
-docker compose build
+docker compose build --build-arg KAKADU_ZIP=<name of zip file>
 docker compose up
 ```
 

--- a/hydra-derivatives.gemspec
+++ b/hydra-derivatives.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'deprecation'
   spec.add_dependency 'mime-types', '> 2.0', '< 4.0'
   spec.add_dependency 'mini_magick', '>= 3.2', '< 5'
+  spec.add_dependency 'ruby-vips'
 end

--- a/lib/hydra/derivatives/services/image_service.rb
+++ b/lib/hydra/derivatives/services/image_service.rb
@@ -13,8 +13,11 @@ module Hydra::Derivatives
       when 'graphicsmagick'
         Hydra::Derivatives::Logger.debug('[ImageProcessor] Using GraphicsMagick as image processor')
         :graphicsmagick
+      when 'libvips'
+        Hydra::Derivatives::Logger.debug('[ImageProcessor] Using libvips as image processor')
+        :libvips
       else
-        Hydra::Derivatives::Logger.debug("[ImageProcessor] The environment variable IMAGE_PROCESSOR should be set to either 'imagemagick' or 'graphicsmagick'. It is currently set to: #{ENV['IMAGE_PROCESSOR']}. Defaulting to using #{default_processor}")
+        Hydra::Derivatives::Logger.debug("[ImageProcessor] The environment variable IMAGE_PROCESSOR should be set to 'imagemagick','graphicsmagick' or 'libvips'. It is currently set to: #{ENV['IMAGE_PROCESSOR']}. Defaulting to using #{default_processor}")
         default_processor
       end
     end

--- a/spec/processors/image_spec.rb
+++ b/spec/processors/image_spec.rb
@@ -188,6 +188,117 @@ describe Hydra::Derivatives::Processors::Image do
     end
   end
 
+  context 'using libvips' do
+    let(:mock_image) { double }
+
+    before do
+      allow(subject).to receive(:write_image_with_vips).and_call_original
+      allow(mock_image).to receive(:thumbnail_image).and_return(mock_image)
+      allow(mock_image).to receive(:write_to_buffer)
+    end
+
+    around do |example|
+      cached_image_processor = ENV['IMAGE_PROCESSOR']
+      ENV['IMAGE_PROCESSOR'] = 'libvips'
+      example.run
+      ENV['IMAGE_PROCESSOR'] = cached_image_processor
+    end
+
+    context 'with an image source file' do
+
+      before do
+        allow(Vips::Image).to receive(:new_from_file).with(file_name).and_return(mock_image)
+        allow(subject.output_file_service).to receive(:call)
+        allow_any_instance_of(described_class).to receive(:`).with("vipsheader #{file_name}").and_return "300x386 uchar, 3 bands, srgb, tiffload"
+      end
+
+      context 'with size directive' do
+        let(:file_name) { File.join(fixture_path, "test.tif") }
+
+        context 'when shrinking image down' do
+          let(:directives) { { label: :thumb, size: '200x300>', format: 'png', quality: 75 } }
+
+          it 'interprets size directives from imagemagick/graphicsmagick syntax' do
+            expect(mock_image).to receive(:thumbnail_image).with(200, height: 300, size: :down)
+            subject.process
+          end
+
+          it 'writes the image file using format and quality directives' do
+            expect(subject).to receive(:write_image_with_vips).with(mock_image, directives)
+            expect(mock_image).to receive(:write_to_buffer).with('.png[Q=75]')
+            subject.process
+          end
+        end
+
+        context 'when sizing image up' do
+          let(:directives) { { label: :thumb, size: '200x300<' } }
+
+          it 'interprets size directives from imagemagick/graphicsmagick syntax' do
+            expect(mock_image).to receive(:thumbnail_image).with(200, height: 300, size: :up)
+            subject.process
+          end
+        end
+
+        context 'when ignoring original aspect ratio' do
+          let(:directives) { { label: :thumb, size: '200x300!' } }
+
+          it 'interprets size directives from imagemagick/graphicsmagick syntax' do
+            expect(mock_image).to receive(:thumbnail_image).with(200, height: 300, size: :force)
+            subject.process
+          end
+        end
+      end
+
+    end
+
+    context 'with a pdf source file' do
+      before do
+        allow(subject.output_file_service).to receive(:call)
+        allow(Vips::Image).to receive(:new_from_file).with(any_args).and_call_original
+      end
+
+      let(:file_name) { File.join(fixture_path, "multipage.pdf") }
+
+      context 'when no layer directive is specified' do
+        let(:directives) { { label: :thumb, size: '200x300>', format: 'png', quality: 75 } }
+
+        it 'does not load the file with a specific page (i.e. defaults to first page)' do
+          expect(Vips::Image).to receive(:new_from_file).with(file_name)
+          subject.process
+        end
+      end
+
+      context 'when specifying a layer' do
+        let(:directives) { { label: :thumb, size: '200x300>', format: 'png', quality: 75, layer: 1 } }
+
+        it 'loads the file with the specified page' do
+          expect(Vips::Image).to receive(:new_from_file).with(file_name, page: 1)
+          subject.process
+        end
+      end
+    end
+
+    context 'when running the complete command' do
+      let(:directives) { { size: '100x100>', format: 'png' } }
+
+      context 'with an image' do
+        let(:file_name) { File.join(fixture_path, "test.tif") }
+
+        it 'calls the libvips version of create_resized_image' do
+          expect(subject).to receive(:create_resized_image_with_libvips)
+          subject.process
+        end
+
+        it 'converts the image' do
+          expect(Hydra::Derivatives::PersistBasicContainedOutputFileService).to receive(:call).with(kind_of(StringIO), directives)
+          subject.process
+        end
+      end
+
+    end
+
+  end
+
   context 'using default processor (imagemagick)' do
     before do
       allow(MiniMagick).to receive(:cli).and_return(:imagemagick)


### PR DESCRIPTION
Building on work in #255, I'd like to add support for [(lib)vips](https://www.libvips.org/) as an optional processor for image and pdf derivatives.

Rails seems to be moving away from imagemagick and towards vips for [performance reasons](https://discuss.rubyonrails.org/t/make-vips-the-recommended-default-variant-processor-for-active-storage/78368), and vips is the [default variant processor](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#active-storage-default-variant-processor-changed-to-vips) as of Rails 7. So I think providing this option makes sense. 

To use libvips as the image processor, set the `IMAGE_PROCESSOR` env variable to `libvips`. 

Notes:
- this PR adds the [ruby-vips gem](https://github.com/libvips/ruby-vips) as a dependency
- Compatibility with `size` and `layers` directives is maintained (e.g. `size: '300x150>'`, `layers: 1`), so downstream apps do not need to change them
- I also updated the Dockerfile and instructions to account for the fact that Kakadu is no longer available via `wget` (email verification is required)